### PR TITLE
Règle un bug sur l'API de liste des referral lite

### DIFF
--- a/src/backend/partaj/core/api/referral_lite.py
+++ b/src/backend/partaj/core/api/referral_lite.py
@@ -49,7 +49,7 @@ class ReferralLiteViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             except models.UnitMembership.DoesNotExist:
                 return Response(status=403)
 
-            queryset = queryset.filter(topic__unit=unit).order_by("due_date")
+            queryset = queryset.filter(units=unit).order_by("due_date")
 
             page = self.paginate_queryset(queryset)
             if page is not None:

--- a/src/backend/tests/partaj/core/test_api_referrallite.py
+++ b/src/backend/tests/partaj/core/test_api_referrallite.py
@@ -108,6 +108,25 @@ class ReferralLiteApiTestCase(TestCase):
         self.assertEqual(response.json()["results"][0]["id"], referrals[0].id)
         self.assertEqual(response.json()["results"][1]["id"], referrals[1].id)
 
+    def test_list_referrals_for_unit_by_unit_member_with_changed_assignment(self):
+        """
+        Make sure list referral lite requests also get units that are not associated
+        with the referral topic.
+        """
+        user = factories.UserFactory()
+        unit_2 = factories.UnitFactory()
+        unit_2.members.add(user)
+        referral = factories.ReferralFactory()
+        referral.units.add(unit_2)
+
+        response = self.client.get(
+            f"/api/referrallites/?unit={unit_2.id}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["id"], referral.id)
+
     def test_list_referrals_for_unit_by_unit_member_performance(self):
         """
         Make the request with a large number of referrals to make sure the number of queries


### PR DESCRIPTION
## Purpose

As we reworked units link to referrals to use a through relationship instead of relying on the topic itself, we missed one use in the referral lite list endpoint as a filter.

## Proposal

Add a test to make sure we properly fix it and make the update.