### PR TITLE
🐛(ci) fix flake8 run in the CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install python dependencies
       run: pip install .[dev]
     - name: Run flake8
-      run: flake8 partaj
+      run: flake8
   lint-pylint:
     runs-on: ubuntu-latest
     container: python:3.7-stretch

--- a/src/backend/tests/partaj/core/test_api_referralactivity.py
+++ b/src/backend/tests/partaj/core/test_api_referralactivity.py
@@ -40,8 +40,8 @@ class ReferralApiTestCase(TestCase):
 
     def test_list_referralactivity_by_referral_linked_unit_member(self):
         """
-        The relevant referral's linked unit members can make list requests on referral activity, and
-        they get to see all types of activities.
+        The relevant referral's linked unit members can make list requests on referral activity,
+        and they get to see all types of activities.
         """
         user = factories.UserFactory()
         create_activity = factories.ReferralActivityFactory(
@@ -181,8 +181,8 @@ class ReferralApiTestCase(TestCase):
 
     def test_list_referralactivity_by_referral_linked_user_also_unit_member(self):
         """
-        If a given user is both the referral linked user and a linked unit member, they get to see all
-        types of activity.
+        If a given user is both the referral linked user and a linked unit member, they get to
+        see all types of activity.
         """
         user = factories.UserFactory()
         create_activity = factories.ReferralActivityFactory(

--- a/src/backend/tests/partaj/core/test_api_referralanswer.py
+++ b/src/backend/tests/partaj/core/test_api_referralanswer.py
@@ -446,7 +446,8 @@ class ReferralAnswerApiTestCase(TestCase):
 
     def test_update_nonexistent_referralanswer(self):
         """
-        An appropriate error is returned when a user attempts to update an answer that does not exist.
+        An appropriate error is returned when a user attempts to update an answer
+        that does not exist.
         """
         user = factories.UserFactory()
         nonexistent_answer_id = uuid.uuid4()
@@ -506,6 +507,7 @@ class ReferralAnswerApiTestCase(TestCase):
         A given referral's linked user cannot remove attachments from answers to their referral.
         """
         answer = factories.ReferralAnswerFactory(state=models.ReferralAnswerState.DRAFT)
+        user = answer.referral.user
         attachment = factories.ReferralAnswerAttachmentFactory()
         attachment.referral_answers.add(answer)
         answer.refresh_from_db()
@@ -515,7 +517,7 @@ class ReferralAnswerApiTestCase(TestCase):
             f"/api/referralanswers/{answer.id}/remove_attachment/",
             {"attachment": attachment.id},
             content_type="application/json",
-            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=answer.referral.user)[0]}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
         self.assertEqual(response.status_code, 403)

--- a/src/backend/tests/partaj/core/test_api_referralanswerattachments.py
+++ b/src/backend/tests/partaj/core/test_api_referralanswerattachments.py
@@ -50,11 +50,12 @@ class ReferralAnswerAttachmentApiTestCase(TestCase):
         A referral's linked user cannot create attachments for answers to their referral.
         """
         answer = factories.ReferralAnswerFactory()
+        user = answer.referral.user
         self.assertEqual(models.ReferralAnswerAttachment.objects.all().count(), 0)
         response = self.client.post(
             "/api/referralanswerattachments/",
             {"answer": str(answer.id), "files": (BytesIO(b"attachment_file"),)},
-            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=answer.referral.user)[0]}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
         self.assertEqual(response.status_code, 403)

--- a/src/backend/tests/partaj/core/test_api_referralanswervalidationrequest.py
+++ b/src/backend/tests/partaj/core/test_api_referralanswervalidationrequest.py
@@ -44,11 +44,12 @@ class ReferralAnswerValidationRequestApiTestCase(TestCase):
         answers to their referral.
         """
         answer = factories.ReferralAnswerFactory()
+        user = answer.referral.user
         factories.ReferralAnswerValidationRequestFactory.create_batch(2, answer=answer)
         response = self.client.get(
             "/api/referralanswervalidationrequests/",
             {"answer": str(answer.id)},
-            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=answer.referral.user)[0]}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
         self.assertEqual(response.status_code, 403)
 

--- a/src/backend/tests/partaj/users/test_users.py
+++ b/src/backend/tests/partaj/users/test_users.py
@@ -1,11 +1,10 @@
-from django.dispatch import receiver
-from django.test import RequestFactory, TestCase
-from django_cas_ng.models import SessionTicket
-from django_cas_ng.signals import cas_user_authenticated, cas_user_logout
+from django.test import TestCase
+
+from django_cas_ng.signals import cas_user_authenticated
+
 from partaj.core.factories import UnitFactory, UnitMembershipFactory, UserFactory
 from partaj.core.models.unit import UnitMembership, UnitMembershipRole
-from partaj.users.auth import CerbereCASBackend
-from partaj.users.signals import cas_user_authenticated_callback
+from partaj.users import signals  # noqa: F401 # pylint: disable=unused-import
 
 
 class UsersTestCase(TestCase):
@@ -51,7 +50,7 @@ class UsersTestCase(TestCase):
         """
         if new user's unit doesn't exist: no assignment
         """
-        unit = UnitFactory()
+        UnitFactory()
         user = UserFactory()
 
         cas_user_authenticated.send(


### PR DESCRIPTION
## Purpose

flake8 was not actually being ran by the CI due to a mistake in the command line.

## Proposal

Remove the unnecessary argument so flake8 can run and catch mistakes as intended.