### PR TITLE
Fix randomly failing tests in `<ReferralDetailAssignment />`

### DIFF
--- a/src/frontend/js/components/ReferralDetailAssignment/index.spec.tsx
+++ b/src/frontend/js/components/ReferralDetailAssignment/index.spec.tsx
@@ -24,6 +24,16 @@ describe('<ReferralDetailAssignment />', () => {
       // the referral topic.
       const unit: Unit = factories.UnitFactory.generate();
       unit.members = factories.UnitMemberFactory.generate(5);
+      unit.members[0].first_name = 'André';
+      unit.members[0].last_name = 'François';
+      unit.members[1].first_name = 'Bernard';
+      unit.members[1].last_name = 'Georges';
+      unit.members[2].first_name = 'César';
+      unit.members[2].last_name = 'Henry';
+      unit.members[3].first_name = 'David';
+      unit.members[3].last_name = 'Joël';
+      unit.members[4].first_name = 'Eric';
+      unit.members[4].last_name = 'Laurent';
       unit.members[0].membership.role = role;
 
       it('shows an empty list of assignees and a dropdown menu to manage members assignments', async () => {


### PR DESCRIPTION
## Purpose

Some tests for `<ReferralDetailAssignment />` were randomly failing: the UI in this component uses initials to represent users, and due to the high probability of collisions with a string that is 2 characters long, randomly generating user first and last names causes unreliable tests.

## Proposal

Simply hardcoding names with different initials for users should make these tests stop breaking randomly.