### PR TITLE
Add a customer success third-party tool

### DIFF
--- a/src/backend/partaj/core/context_processors.py
+++ b/src/backend/partaj/core/context_processors.py
@@ -18,6 +18,7 @@ def partaj_context(request):
     """
     frontend_context = {
         "assets": {"icons": static("core/icons.svg")},
+        "crisp_website_id": settings.CRISP_WEBSITE_ID,
         "csrftoken": get_token(request),
         "environment": settings.ENVIRONMENT,
         "url_admin": reverse("admin:index"),

--- a/src/backend/partaj/core/templates/core/base.html
+++ b/src/backend/partaj/core/templates/core/base.html
@@ -1,14 +1,24 @@
 {% load i18n static %}
 
-<!doctype html>
-<html lang="fr-FR" class="{% block htmlrootclass %}{% endblock htmlrootclass %}">
+<!DOCTYPE html>
+<html
+  lang="fr-FR"
+  class="{% block htmlrootclass %}{% endblock htmlrootclass %}"
+>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
 
     <title>Partaj</title>
 
-    <link rel="stylesheet" type="text/css" href="{% static 'css/styles.css' %}">
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{% static 'css/styles.css' %}"
+    />
     <!--
       Fix a nasty issue in Safari where it is impossible to make a table-row into a containing block. When we then stretch
       the links in our tables it breaks and covers the whole page. This safari only hack enables us to disable link-stretching
@@ -16,7 +26,13 @@
       Users then have to click on the actual link in the row header.
     -->
     <style>
-      @media not all and (min-resolution:.001dpcm) {  @media { .stretched-link:after { display:none; } } }
+      @media not all and (min-resolution: 0.001dpcm) {
+        @media {
+          .stretched-link:after {
+            display: none;
+          }
+        }
+      }
     </style>
 
     {% block htmlhead %}{% endblock htmlhead %}
@@ -28,8 +44,30 @@
     <!-- Entypo pictograms by Daniel Bruce — www.entypo.com -->
 
     <script>
-      window.__partaj_frontend_context__ = JSON.parse('{{ FRONTEND_CONTEXT|safe }}');
+      window.__partaj_frontend_context__ = JSON.parse(
+        '{{ FRONTEND_CONTEXT|safe }}',
+      );
     </script>
     <script src="{% static 'js/index.js' %}"></script>
+    <script type="text/javascript">
+      /**
+       * Third-party customer relationship tool.
+       */
+      if (
+        window.__partaj_frontend_context__ &&
+        window.__partaj_frontend_context__.crisp_website_id
+      ) {
+        window.$crisp = [];
+        window.CRISP_WEBSITE_ID =
+          window.__partaj_frontend_context__.crisp_website_id;
+        (function () {
+          d = document;
+          s = d.createElement('script');
+          s.src = 'https://client.crisp.chat/l.js';
+          s.async = 1;
+          d.getElementsByTagName('head')[0].appendChild(s);
+        })();
+      }
+    </script>
   </body>
 </html>

--- a/src/backend/partaj/settings.py
+++ b/src/backend/partaj/settings.py
@@ -295,6 +295,7 @@ class Base(SendinblueMixin, DRFMixin, Configuration):
     # Third party tools keys
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
     SABER_KEY = values.Value(None, environ_name="SABER_KEY")
+    CRISP_WEBSITE_ID = values.Value(None, environ_name="CRISP_WEBSITE_ID")
 
     # Enable impersonation from the back-office
     SESSION_SERIALIZER = "partaj.users.serializers.FixImpersonateJSONSerializer"


### PR DESCRIPTION
Add the third-party tool we chose (Crisp chat) through their JS blob on the base template, and a setting to manage unique IDs for our environments.