### PR TITLE
♻️(frontend) handle stale closure problem in useClickOutside

### DIFF
--- a/src/frontend/js/utils/useClickOutside/index.spec.tsx
+++ b/src/frontend/js/utils/useClickOutside/index.spec.tsx
@@ -39,4 +39,27 @@ describe('useClickOutside', () => {
     userEvent.click(screen.getByText('Sibling component'));
     expect(handler).toHaveBeenCalled();
   });
+
+  it('calls the latest handler (make sure the stale closure problem is handled)', () => {
+    const oldHandler = jest.fn();
+    const newHandler = jest.fn();
+
+    const { rerender } = render(
+      <>
+        <TestComponent handler={oldHandler} />
+        <SiblingComponent />
+      </>,
+    );
+
+    rerender(
+      <>
+        <TestComponent handler={newHandler} />
+        <SiblingComponent />
+      </>,
+    );
+
+    userEvent.click(screen.getByText('Sibling component'));
+    expect(newHandler).toHaveBeenCalled();
+    expect(oldHandler).not.toHaveBeenCalled();
+  });
 });

--- a/src/frontend/js/utils/useClickOutside/index.tsx
+++ b/src/frontend/js/utils/useClickOutside/index.tsx
@@ -5,10 +5,15 @@ import { Nullable } from 'types/utils';
 export const useClickOutside = (onClick: Function) => {
   const ref = useRef<Nullable<HTMLElement>>(null);
 
+  const onClickRef = useRef(onClick);
+  useEffect(() => {
+    onClickRef.current = onClick;
+  }, [onClick]);
+
   const handleEvent: EventListener = (event) => {
     if (ref && ref.current) {
       if (!ref.current.contains(event.target as Nullable<HTMLElement>)) {
-        onClick();
+        onClickRef.current();
       }
     }
   };


### PR DESCRIPTION
## Purpose

useClickOutside was creating bugs due to the stale closure problem: it worked fine when `onClick` never changed during the whole lifecycle of the hook, but did not take into account updated values for onClick.

## Proposal

We cannot manage this with a dependency array as we want to avoid creating a memory leak with a bunch of event listeners. Instead, we can use a mutable ref to keep an up-to-date onClick reference inside our closure.