### PR TITLE
🐛(frontend) fix an issue in <ReferralDetailAnswerDisplay />

### DIFF
--- a/src/frontend/js/components/ReferralDetailAnswerDisplay/index.tsx
+++ b/src/frontend/js/components/ReferralDetailAnswerDisplay/index.tsx
@@ -75,9 +75,10 @@ export const ReferralDetailAnswerDisplay = ({
             {...messages.byWhom}
             values={{
               name: getUserFullname(answer.created_by),
-              unit_name: referral.units.filter((unit) =>
-                isUserUnitMember(answer.created_by, unit),
-              )[0].name,
+              unit_name:
+                referral.units.filter((unit) =>
+                  isUserUnitMember(answer.created_by, unit),
+                )[0]?.name || '',
             }}
           />
         </div>


### PR DESCRIPTION
## Purpose

In some cases, the <ReferralDetailAnswerDisplay /> component was broken when it failed to find the unit the answer author belongs to among the units linked to the referral. Add an undefined check to avoid breaking in those cases.