### PR TITLE
🐛(deployment) fix ever-expanding static folder

### DIFF
--- a/.github/workflows/partaj-ci.yml
+++ b/.github/workflows/partaj-ci.yml
@@ -245,6 +245,11 @@ jobs:
         git checkout ${{ github.ref == 'refs/heads/production' && 'deployment-production' || 'deployment-staging' }}
     - name: Copy the actual Partaj source files (and frontend build results) to the deployment directory
       run: |
+        mkdir ../temp
+        cp -R ../deployment/.git ../temp
+        rm -rf ../deployment/*
+        mv -R ../temp/.git ../deployment
+        rm -rf ../temp
         cp -R src/backend/* ../deployment
         cp docker/files/usr/local/etc/gunicorn/partaj.py ../deployment/partaj-gunicorn.py
     - name: Generate a requirements.txt file from setup.cfg


### PR DESCRIPTION
## Purpose

As we built our deployment script, we made it as an additive process, always adding new files into the repo, never removing deleted files.

This started causing issues as the frontend build is generating 1600 files per deployment. This is quickly growing the size of the static folder with unused old files, and overwhelming our whitenoise which is failing to serve anything.