### PR TITLE
🐛(emails) fix broken link in add requeter email

### DIFF
--- a/src/backend/partaj/core/email.py
+++ b/src/backend/partaj/core/email.py
@@ -288,7 +288,7 @@ class Mailer:
             "params": {
                 "case_number": referral.id,
                 "created_by": created_by.get_full_name(),
-                "link_to_referral": link_path,
+                "link_to_referral": f"{cls.location}{link_path}",
                 "topic": referral.topic.name,
                 "urgency": referral.urgency_level.name,
             },

--- a/src/backend/tests/partaj/core/test_api_referral_add_requester.py
+++ b/src/backend/tests/partaj/core/test_api_referral_add_requester.py
@@ -87,7 +87,10 @@ class ReferralApiAddRequesterTestCase(TestCase):
                 "params": {
                     "case_number": referral.id,
                     "created_by": user.get_full_name(),
-                    "link_to_referral": f"/app/sent-referrals/referral-detail/{referral.id}",
+                    "link_to_referral": (
+                        "https://partaj/app/sent-referrals"
+                        f"/referral-detail/{referral.id}"
+                    ),
                     "topic": referral.topic.name,
                     "urgency": referral.urgency_level.name,
                 },
@@ -131,7 +134,10 @@ class ReferralApiAddRequesterTestCase(TestCase):
                 "params": {
                     "case_number": referral.id,
                     "created_by": user.get_full_name(),
-                    "link_to_referral": f"/app/sent-referrals/referral-detail/{referral.id}",
+                    "link_to_referral": (
+                        "https://partaj/app/sent-referrals"
+                        f"/referral-detail/{referral.id}"
+                    ),
                     "topic": referral.topic.name,
                     "urgency": referral.urgency_level.name,
                 },
@@ -236,7 +242,10 @@ class ReferralApiAddRequesterTestCase(TestCase):
                 "params": {
                     "case_number": referral.id,
                     "created_by": user.get_full_name(),
-                    "link_to_referral": f"/app/sent-referrals/referral-detail/{referral.id}",
+                    "link_to_referral": (
+                        "https://partaj/app/sent-referrals"
+                        f"/referral-detail/{referral.id}"
+                    ),
                     "topic": referral.topic.name,
                     "urgency": referral.urgency_level.name,
                 },
@@ -275,7 +284,10 @@ class ReferralApiAddRequesterTestCase(TestCase):
                 "params": {
                     "case_number": referral.id,
                     "created_by": user.get_full_name(),
-                    "link_to_referral": f"/app/sent-referrals/referral-detail/{referral.id}",
+                    "link_to_referral": (
+                        "https://partaj/app/sent-referrals"
+                        f"/referral-detail/{referral.id}"
+                    ),
                     "topic": referral.topic.name,
                     "urgency": referral.urgency_level.name,
                 },
@@ -314,7 +326,10 @@ class ReferralApiAddRequesterTestCase(TestCase):
                 "params": {
                     "case_number": referral.id,
                     "created_by": user.get_full_name(),
-                    "link_to_referral": f"/app/sent-referrals/referral-detail/{referral.id}",
+                    "link_to_referral": (
+                        "https://partaj/app/sent-referrals"
+                        f"/referral-detail/{referral.id}"
+                    ),
                     "topic": referral.topic.name,
                     "urgency": referral.urgency_level.name,
                 },
@@ -353,7 +368,10 @@ class ReferralApiAddRequesterTestCase(TestCase):
                 "params": {
                     "case_number": referral.id,
                     "created_by": user.get_full_name(),
-                    "link_to_referral": f"/app/sent-referrals/referral-detail/{referral.id}",
+                    "link_to_referral": (
+                        "https://partaj/app/sent-referrals"
+                        f"/referral-detail/{referral.id}"
+                    ),
                     "topic": referral.topic.name,
                     "urgency": referral.urgency_level.name,
                 },


### PR DESCRIPTION
## Purpose

When a new requester is added to a referral, we send them an email with a link to the referral. The link was broken due to the omission of the domain in the URL.