### PR TITLE
Rework referral lite lists to use get_queryset and regular query parameters

### DIFF
--- a/src/backend/partaj/core/api/referral_lite.py
+++ b/src/backend/partaj/core/api/referral_lite.py
@@ -5,13 +5,15 @@ from django.contrib.auth import get_user_model
 from django.db.models import DateTimeField, Exists, ExpressionWrapper, F, OuterRef, Q
 
 import arrow
-from rest_framework import mixins, viewsets
-from rest_framework.decorators import action
+from rest_framework import exceptions, mixins, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from .. import models
 from ..serializers import ReferralLiteSerializer
+
+# pylint: disable=invalid-name
+User = get_user_model()
 
 
 class ReferralLiteViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -31,205 +33,149 @@ class ReferralLiteViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     ).annotate(unit=F("topic__unit__id"))
     serializer_class = ReferralLiteSerializer
 
+    def get_queryset(self):
+        """
+        Apply all relevant filters in the query parameters and return a ready-to-use queryset.
+        """
+        queryset = self.queryset.prefetch_related("assignees", "users")
+
+        unit = self.request.query_params.get("unit", None)
+        if unit is not None:
+            try:
+                unit = models.Unit.objects.get(id=unit)
+            except models.Unit.DoesNotExist as exc:
+                raise exceptions.ValidationError(
+                    detail=[f"Unit {unit} does not exist."]
+                ) from exc
+            # Make sure the user is a member of the unit and can make this request
+            try:
+                models.UnitMembership.objects.get(unit=unit, user=self.request.user)
+            except models.UnitMembership.DoesNotExist as exc:
+                raise exceptions.PermissionDenied from exc
+            queryset = queryset.filter(units=unit)
+
+        user = self.request.query_params.get("user", None)
+        if user is not None:
+            try:
+                user = User.objects.get(id=user)
+            except User.DoesNotExist as exc:
+                raise exceptions.ValidationError(
+                    detail=[f"User {user} does not exist."]
+                ) from exc
+            # Requests to filter on a given user can only be performed by said user themselves
+            if user != self.request.user:
+                raise exceptions.PermissionDenied
+            queryset = queryset.filter(users=user)
+
+        task = self.request.query_params.get("task", None)
+        if task == "answer_soon":
+            # Get a list of referrals that need to be answered soon if:
+            # - the user is assigned to this referral;
+            # - the user is owner on the related unit.
+            queryset = (
+                queryset.annotate(
+                    is_owned_by_user=Exists(
+                        models.UnitMembership.objects.filter(
+                            unit=OuterRef("topic__unit"),
+                            user=self.request.user,
+                            role=models.UnitMembershipRole.OWNER,
+                        )
+                    )
+                )
+                .annotate(
+                    is_user_assigned=Exists(
+                        models.ReferralAssignment.objects.filter(
+                            assignee=self.request.user,
+                            referral__id=OuterRef("id"),
+                        )
+                    ),
+                )
+                .exclude(
+                    (Q(is_owned_by_user=False) & Q(is_user_assigned=False))
+                    | Q(
+                        state__in=[
+                            models.ReferralState.ANSWERED,
+                            models.ReferralState.CLOSED,
+                        ]
+                    )
+                    | Q(due_date__gt=arrow.utcnow().shift(days=15).datetime),
+                )
+            )
+        elif task == "assign":
+            # Get a list of referrals up for assignment by the current user.
+            queryset = queryset.annotate(
+                is_owned_by_user=Exists(
+                    models.UnitMembership.objects.filter(
+                        unit=OuterRef("topic__unit"),
+                        user=self.request.user,
+                        role=models.UnitMembershipRole.OWNER,
+                    )
+                )
+            ).filter(is_owned_by_user=True, state=models.ReferralState.RECEIVED)
+        elif task == "process":
+            # Get a list of referrals up for processing by the current user.
+            queryset = (
+                queryset.annotate(
+                    has_active_assignment=Exists(
+                        models.ReferralAssignment.objects.filter(
+                            assignee=self.request.user,
+                            referral__id=OuterRef("id"),
+                            referral__state=models.ReferralState.ASSIGNED,
+                        )
+                    ),
+                )
+                .annotate(
+                    has_validation_request=Exists(
+                        models.ReferralAnswerValidationRequest.objects.filter(
+                            answer__referral__id=OuterRef("id")
+                        )
+                    ),
+                )
+                .filter(has_active_assignment=True, has_validation_request=False)
+            )
+        elif task == "validate":
+            # Get a list of referrals up for validation by the current user.
+            queryset = queryset.annotate(
+                has_active_validation_request=Exists(
+                    models.ReferralAnswerValidationRequest.objects.filter(
+                        answer__referral__id=OuterRef("id"),
+                        response=None,
+                        validator=self.request.user,
+                    )
+                )
+            ).filter(
+                has_active_validation_request=True,
+                state=models.ReferralState.IN_VALIDATION,
+            )
+        else:
+            # Make sure permissions cannot be bypassed by setting a bogus task
+            task = None
+
+        # Tasks manage their own authorization restrictions, otherwise unit/user filter is required
+        if task is None and unit is None and user is None:
+            raise exceptions.ValidationError(
+                detail=[
+                    "Referral list requests require at least a task/unit/user parameter."
+                ]
+            )
+
+        return queryset
+
     def list(self, request, *args, **kwargs):
         """
         Handle requests for lists of referrals. We're managing access rights inside the method
         as permissions depend on the supplied parameters.
         """
-        queryset = self.get_queryset().prefetch_related("assignees", "users")
+        try:
+            queryset = self.get_queryset()
+        except exceptions.ValidationError as exc:
+            return Response(status=400, data={"errors": exc.detail})
+        except exceptions.PermissionDenied:
+            # - request is filtering on a unit, but current user is not a member of that unit
+            # - request is filtering on a user who is no the current user
+            return Response(status=403)
 
-        unit = self.request.query_params.get("unit", None)
-        if unit is not None:
-            # Get the unit, return an error if it does not exist
-            try:
-                unit = models.Unit.objects.get(id=unit)
-            except models.Unit.DoesNotExist:
-                return Response(
-                    status=400, data={"errors": [f"Unit {unit} does not exist."]}
-                )
-
-            # Make sure the user is a member of the unit and can make this request
-            try:
-                models.UnitMembership.objects.get(unit=unit, user=request.user)
-            except models.UnitMembership.DoesNotExist:
-                return Response(status=403)
-
-            queryset = queryset.filter(units=unit).order_by("due_date")
-
-            page = self.paginate_queryset(queryset)
-            if page is not None:
-                serializer = self.get_serializer(page, many=True)
-                return self.get_paginated_response(serializer.data)
-
-            serializer = self.get_serializer(queryset, many=True)
-            return Response(serializer.data)
-
-        user = self.request.query_params.get("user", None)
-        if user is not None:
-            # Get the user, return an error if it does not exist
-            try:
-                # pylint: disable=invalid-name
-                User = get_user_model()
-                user = User.objects.get(id=user)
-            except User.DoesNotExist:
-                return Response(
-                    status=400, data={"errors": [f"User {user} does not exist."]}
-                )
-
-            if user != request.user:
-                return Response(status=403)
-
-            queryset = queryset.filter(users=user).order_by("due_date")
-
-            page = self.paginate_queryset(queryset)
-            if page is not None:
-                serializer = self.get_serializer(page, many=True)
-                return self.get_paginated_response(serializer.data)
-
-            serializer = self.get_serializer(queryset, many=True)
-            return Response(serializer.data)
-
-        return Response(
-            status=400,
-            data={"errors": ["Referral list requests require parameters"]},
-        )
-
-    @action(detail=False)
-    def to_answer_soon(self, request):
-        """
-        Get a list of referrals that need to be answered soon if:
-            - the user is assigned to this referral;
-            - the user is owner on the related unit.
-        """
-
-        queryset = (
-            self.get_queryset()
-            .annotate(
-                is_owned_by_user=Exists(
-                    models.UnitMembership.objects.filter(
-                        unit=OuterRef("topic__unit"),
-                        user=request.user,
-                        role=models.UnitMembershipRole.OWNER,
-                    )
-                )
-            )
-            .annotate(
-                is_user_assigned=Exists(
-                    models.ReferralAssignment.objects.filter(
-                        assignee=request.user,
-                        referral__id=OuterRef("id"),
-                    )
-                ),
-            )
-            .exclude(
-                (Q(is_owned_by_user=False) & Q(is_user_assigned=False))
-                | Q(
-                    state__in=[
-                        models.ReferralState.ANSWERED,
-                        models.ReferralState.CLOSED,
-                    ]
-                )
-                | Q(due_date__gt=arrow.utcnow().shift(days=15).datetime),
-            )
-            .order_by("due_date")
-        )
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
-
-    @action(detail=False)
-    def to_assign(self, request):
-        """
-        Get a list of referrals up for assignment by the current user.
-        """
-
-        queryset = (
-            self.get_queryset()
-            .annotate(
-                is_owned_by_user=Exists(
-                    models.UnitMembership.objects.filter(
-                        unit=OuterRef("topic__unit"),
-                        user=request.user,
-                        role=models.UnitMembershipRole.OWNER,
-                    )
-                )
-            )
-            .filter(is_owned_by_user=True, state=models.ReferralState.RECEIVED)
-            .order_by("due_date")
-        )
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
-
-    @action(detail=False)
-    def to_process(self, request):
-        """
-        Get a list of referrals up for processing by the current user.
-        """
-
-        queryset = (
-            self.get_queryset()
-            .annotate(
-                has_active_assignment=Exists(
-                    models.ReferralAssignment.objects.filter(
-                        assignee=request.user,
-                        referral__id=OuterRef("id"),
-                        referral__state=models.ReferralState.ASSIGNED,
-                    )
-                ),
-            )
-            .annotate(
-                has_validation_request=Exists(
-                    models.ReferralAnswerValidationRequest.objects.filter(
-                        answer__referral__id=OuterRef("id")
-                    )
-                ),
-            )
-            .filter(has_active_assignment=True, has_validation_request=False)
-            .order_by("due_date")
-        )
-
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(serializer.data)
-
-    @action(detail=False)
-    def to_validate(self, request):
-        """
-        Get a list of referrals up for validation by the current user.
-        """
-
-        queryset = (
-            self.get_queryset()
-            .annotate(
-                has_active_validation_request=Exists(
-                    models.ReferralAnswerValidationRequest.objects.filter(
-                        answer__referral__id=OuterRef("id"),
-                        response=None,
-                        validator=request.user,
-                    )
-                )
-            )
-            .filter(
-                has_active_validation_request=True,
-                state=models.ReferralState.IN_VALIDATION,
-            )
-            .order_by("due_date")
-        )
+        queryset = queryset.order_by("due_date")
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/src/backend/tests/partaj/core/test_api_referrallite.py
+++ b/src/backend/tests/partaj/core/test_api_referrallite.py
@@ -38,7 +38,12 @@ class ReferralLiteApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response.json(), {"errors": ["Referral list requests require parameters"]}
+            response.json(),
+            {
+                "errors": [
+                    "Referral list requests require at least a task/unit/user parameter."
+                ]
+            },
         )
 
     def test_list_referrals_by_admin_user(self):
@@ -53,7 +58,12 @@ class ReferralLiteApiTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response.json(), {"errors": ["Referral list requests require parameters"]}
+            response.json(),
+            {
+                "errors": [
+                    "Referral list requests require at least a task/unit/user parameter."
+                ]
+            },
         )
 
     def test_list_referrals_for_unit_by_anonymous_user(self):
@@ -249,16 +259,16 @@ class ReferralLiteApiTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"errors": [f"User {id} does not exist."]})
 
-    # TO ANSWER SOON
-    def test_list_tasks_to_answer_soon_by_anonymous_user(self):
+    # ANSWER SOON
+    def test_list_referrals_to_answer_soon_by_anonymous_user(self):
         """
         Anonymous users cannot make requests for tasks to answer soon.
         """
-        response = self.client.get("/api/referrallites/to_answer_soon/")
+        response = self.client.get("/api/referrallites/?task=answer_soon/")
 
         self.assertEqual(response.status_code, 401)
 
-    def test_list_tasks_to_answer_soon_by_unit_member(self):
+    def test_list_referrals_to_answer_soon_by_unit_member(self):
         """
         Unit members should receive only referrals for which they have been assigned
         that are due soon, no matter the current state of the referral.
@@ -351,7 +361,7 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 7)
         response = self.client.get(
-            "/api/referrallites/to_answer_soon/",
+            "/api/referrallites/?task=answer_soon",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
@@ -370,7 +380,11 @@ class ReferralLiteApiTestCase(TestCase):
             expected_referral_2.id,
         )
 
-    def test_list_tasks_to_answer_soon_by_unit_owner(self):
+    def test_list_referrals_to_answer_soon_by_unit_owner(self):
+        """
+        Unit owners should receive all referrals whose due dates are close that are still open,
+        and belong to their unit.
+        """
         # Unit with a topic to match the referrals to it
         unit = factories.UnitFactory()
         topic = factories.TopicFactory(unit=unit)
@@ -440,7 +454,7 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 6)
         response = self.client.get(
-            "/api/referrallites/to_answer_soon/",
+            "/api/referrallites/?task=answer_soon",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
@@ -463,16 +477,16 @@ class ReferralLiteApiTestCase(TestCase):
             expected_referral_1.id,
         )
 
-    # TO ASSIGN
-    def test_list_tasks_to_assign_by_anonymous_user(self):
+    # ASSIGN
+    def test_list_referrals_to_assign_by_anonymous_user(self):
         """
         Anonymous users cannot make requests for tasks to assign.
         """
-        response = self.client.get("/api/referrallites/to_assign/")
+        response = self.client.get("/api/referrallites/?task=assign")
 
         self.assertEqual(response.status_code, 401)
 
-    def test_list_tasks_to_assign_by_unit_member(self):
+    def test_list_referrals_to_assign_by_unit_member(self):
         """
         Unit members can make requests for tasks to assign, but should have no such task.
         """
@@ -487,14 +501,14 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 1)
         response = self.client.get(
-            "/api/referrallites/to_assign/",
+            "/api/referrallites/?task=assign",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 0)
 
-    def test_list_tasks_to_assign_by_unit_owner(self):
+    def test_list_referrals_to_assign_by_unit_owner(self):
         """
         Unit owners can request tasks to assign and get all referrals to their unit that are
         awaiting assignment.
@@ -558,7 +572,7 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 5)
         response = self.client.get(
-            "/api/referrallites/to_assign/",
+            "/api/referrallites/?task=assign",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
@@ -573,16 +587,16 @@ class ReferralLiteApiTestCase(TestCase):
             expected_referrals[1].id,
         )
 
-    # TO PROCESS
-    def test_list_tasks_to_process_by_anonymous_user(self):
+    # PROCESS
+    def test_list_referrals_to_process_by_anonymous_user(self):
         """
         Anonymous users cannot make requests for tasks to process.
         """
-        response = self.client.get("/api/referrallites/to_process/")
+        response = self.client.get("/api/referrallites/?task=process")
 
         self.assertEqual(response.status_code, 401)
 
-    def test_list_tasks_to_process_by_unit_member(self):
+    def test_list_referrals_to_process_by_unit_member(self):
         """
         Unit members should receive only active referrals that are assigned to them
         and not yet submitted to validation.
@@ -648,7 +662,7 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 5)
         response = self.client.get(
-            "/api/referrallites/to_process/",
+            "/api/referrallites/?task=process",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
@@ -663,7 +677,7 @@ class ReferralLiteApiTestCase(TestCase):
             expected_referrals[1].id,
         )
 
-    def test_list_tasks_to_proccess_by_unit_owner(self):
+    def test_list_referrals_to_proccess_by_unit_owner(self):
         """
         Make sure other tasks for unit owners (such as assignments & validations) do not appear
         in the endpoint for processing tasks.
@@ -692,7 +706,7 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 3)
         response = self.client.get(
-            "/api/referrallites/to_process/",
+            "/api/referrallites/?task=process",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
@@ -701,15 +715,15 @@ class ReferralLiteApiTestCase(TestCase):
         self.assertEqual(response.json()["results"][0]["id"], expected_referral.id)
 
     # TO VALIDATE
-    def test_list_tasks_to_validate_by_anonymous_user(self):
+    def test_list_referrals_to_validate_by_anonymous_user(self):
         """
         Anonymous users cannot make requests for tasks to validate.
         """
-        response = self.client.get("/api/referrallites/to_validate/")
+        response = self.client.get("/api/referrallites/?task=validate")
 
         self.assertEqual(response.status_code, 401)
 
-    def test_list_tasks_to_validate_by_validator(self):
+    def test_list_referrals_to_validate_by_validator(self):
         """
         Logged-in users can get a list of the validations that are expected of them.
 
@@ -794,7 +808,7 @@ class ReferralLiteApiTestCase(TestCase):
 
         self.assertEqual(models.Referral.objects.count(), 6)
         response = self.client.get(
-            "/api/referrallites/to_validate/",
+            "/api/referrallites/?task=validate",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 
@@ -803,7 +817,7 @@ class ReferralLiteApiTestCase(TestCase):
         self.assertEqual(response.json()["results"][0]["id"], expected_referral_1.id)
         self.assertEqual(response.json()["results"][1]["id"], expected_referral_2.id)
 
-    def test_list_tasks_to_validate__by_logged_in_user_without_requests(self):
+    def test_list_referrals_to_validate__by_logged_in_user_without_requests(self):
         """
         Logged-in users can get a list of the validations that are expected of them.
         The list just happens to be empty for a regular user with no validations.
@@ -811,7 +825,7 @@ class ReferralLiteApiTestCase(TestCase):
         user = factories.UserFactory()
 
         response = self.client.get(
-            "/api/referrallites/to_validate/",
+            "/api/referrallites/?task=validate",
             HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
         )
 

--- a/src/frontend/js/components/DashboardIndex/index.tsx
+++ b/src/frontend/js/components/DashboardIndex/index.tsx
@@ -95,10 +95,10 @@ export const DashboardIndex: React.FC = () => {
     ? currentUser.memberships.map((membership) => membership.role)
     : [];
 
-  const toAnswerSoon = useReferralLites({ type: 'to_answer_soon' });
-  const toAssign = useReferralLites({ type: 'to_assign' });
-  const toProcess = useReferralLites({ type: 'to_process' });
-  const toValidate = useReferralLites({ type: 'to_validate' });
+  const toAnswerSoon = useReferralLites({ task: 'answer_soon' });
+  const toAssign = useReferralLites({ task: 'assign' });
+  const toProcess = useReferralLites({ task: 'process' });
+  const toValidate = useReferralLites({ task: 'validate' });
 
   return (
     <>

--- a/src/frontend/js/data/index.tsx
+++ b/src/frontend/js/data/index.tsx
@@ -113,22 +113,14 @@ export const useReferralAction = (options?: UseReferralActionOptions) => {
 
 type ReferralLitesResponse = types.APIList<types.ReferralLite>;
 type UseReferralLitesParams =
-  | { type: string }
+  | { task: 'answer_soon' | 'assign' | 'process' | 'validate' }
   | { unit: string }
   | { user: string };
-function isReferralLiteTypeRequest(
-  params: UseReferralLitesParams,
-): params is { type: string } {
-  return !!(params as any).type;
-}
 export const useReferralLites = (
   params: UseReferralLitesParams,
   queryOptions?: FetchListQueryOptions<ReferralLitesResponse>,
 ) => {
-  const key = isReferralLiteTypeRequest(params)
-    ? ([`referrallites/${params.type}`] as const)
-    : (['referrallites', params] as const);
-  return useQuery(key, fetchList, queryOptions);
+  return useQuery(['referrallites', params], fetchList, queryOptions);
 };
 
 type ReferralActivityResponse = types.APIList<types.ReferralActivity>;


### PR DESCRIPTION
## Purpose

As we add more filtering options to all requests for lists of referrals (through referral lites), we need to make sure they all go through the same code paths, and are structured well enough so we can add features without creating a mess.

## Proposal

- [x] move all filtering on the `ReferralLiteViewSet` to `get_queryset()`
- [x] remove task-based endpoints, replace them with query params filtered in `get_queryset()`
- [x] update the frontend to use the new query params instead of task-based endpoints  