### PR TITLE
Add a legal mentions view

### DIFF
--- a/src/backend/partaj/core/templates/core/includes/footer.html
+++ b/src/backend/partaj/core/templates/core/includes/footer.html
@@ -18,6 +18,12 @@
           <a href="mailto:contact@partaj.beta.gouv.fr">{% trans "Contact us" %}</a>
         </li>
         <li>
+          <a href="/stats/">{% trans "Statistics" %}</a>
+        </li>
+        <li>
+          <a href="/legal/">{% trans "Legal mentions" %}</a>
+        </li>
+        <li>
           <a href="https://beta.gouv.fr" target="_blank">{% trans "Beta.gouv network" %}</a>
         </li>
       </ul>

--- a/src/backend/partaj/core/templates/core/legal_mentions.html
+++ b/src/backend/partaj/core/templates/core/legal_mentions.html
@@ -1,0 +1,96 @@
+{% extends "core/base.html" %}
+{% load i18n %}
+
+{% block content %}
+{% include "core/includes/outer_nav.html" %}
+
+<article class="container mx-auto mt-4 mb-8 lg:my-16">
+    <h1 class="font-light text-4xl md:text-5xl lg:text-6xl">Mentions légales</h1>
+
+    <div class="space-y-4">
+    <h2 class="font-semibold text-xl">Mentions d'information RGPD</h2>
+
+    <p>
+      Le traitement PARTAJ est mis en œuvre sous la responsabilité de la Direction des affaires juridiques (DAJ)
+      relevant du ministère de la transition écologique (MTE), du ministère de la cohésion des territoires et des relations
+      avec les collectivités territoriales (MCTRCT) et du ministère de la mer (MMer).
+    </p>
+
+    <p>
+      Les données sont recueillies pour ce traitement dans le cadre de l’exercice de ses missions et pour les finalités
+      suivantes : Traiter, suivre et gérer les demandes d’avis juridiques de la DAJ du Ministère.
+    </p>
+
+    <p>
+      Ces données seront traitées par la DAJ. Elles sont conservées pour une durée de
+    </p>
+
+    <p>
+      Le MTE, le MCTRCT et le MMer s’engagent à ce que les traitements de données à caractère personnel dont il est le responsable
+      de traitement soient mis en œuvre conformément au règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016
+      relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel et à la libre circulation
+      de ces données (ci-après, «règlement général sur la protection des données » ou RGPD) et à la loi n°78-17 du 6 janvier 1978
+      relative à l'informatique, aux fichiers et aux libertés.
+    </p>
+
+    <p>
+      A ce titre, ils traitent les données à caractère personnel recueillies dans le cadre des traitements dont ils ont la responsabilité
+      uniquement pour la ou les seule(s) finalité(s) prédéfinies ainsi qu’à garantir la confidentialité des données à caractère personnel.
+    </p>
+
+    <p>
+      Les personnes concernées par le traitement, conformément à la législation en vigueur, peuvent exercer leurs droits auprès
+      du responsable de traitement.
+    </p>
+
+    <p>
+      Ces droits sont les suivants :
+    </p>
+
+    <ul class="list-disc ml-8">
+      <li class="font-semibold">Droit d’accès aux données</li>
+      <li class="font-semibold">Droit d’information et de vérification</li>
+      <li class="font-semibold">Droit de rectification</li>
+      <li class="font-semibold">Droit à la limitation</li>
+      <li class="font-semibold">Droit à l’effacement</li>
+      <li class="font-semibold">Droit d’opposition</li>
+    </ul>
+
+    <p>
+      Pour toute information ou exercice de vos droits, vous pouvez contacter :
+    </p>
+
+    <ol class="list-decimal ml-8 space-y-4">
+      <li class="whitespace-pre-line">Le responsable de traitement, qui peut être contacté à l’adresse suivante :
+
+        Direction des affaires juridiques, Adjoint à la directrice des affaires juridiques,
+        contact@partaj.beta.gouv.fr
+        Le Ministère de la Transition écologique et solidaire
+        Direction des affaires juridiques
+        Grand Arche paroi Sud
+        Parvis de La Défense
+        92800 Puteaux
+      </li>
+      <li class="whitespace-pre-line">Le délégué à la protection des données (DPD) du MTE, du MCTRCT et du MMer :
+
+        - à l’adresse suivante : dpd.daj.sg@developpement-durable.gouv.fr ;
+        - ou par courrier (avec copie de votre pièce d’identité en cas d’exercice de vos droits) à l’adresse suivante :
+
+        Ministère de la transition écologique
+        Ministère de la cohésion des territoires et des relations avec les collectivités territoriales
+        Ministère de la mer
+        A l’attention du Délégué à la protection des données
+        SG/DAJ/AJAG1-2
+        92055 La Défense cedex
+      </li>
+    </ol>
+
+    <p>
+      Vous avez également la possibilité d’adresser une réclamation relative aux traitements mis en œuvre à la Commission
+      nationale informatique et libertés (3 Place de Fontenoy - TSA 80715 - 75334 PARIS CEDEX 07).
+    </p>
+    </div>
+</article>
+
+{% include "core/includes/footer.html" %}
+{% endblock content %}

--- a/src/backend/partaj/core/urls.py
+++ b/src/backend/partaj/core/urls.py
@@ -43,5 +43,6 @@ urlpatterns = [
     ),
     re_path("app/.*", views.AppView.as_view(), name="app"),
     path("stats/", views.StatsView.as_view(), name="stats"),
+    path("legal/", views.LegalMentionsView.as_view(), name="legal-mentions"),
     path("", views.IndexView.as_view(), name="index"),
 ]

--- a/src/backend/partaj/core/views/common.py
+++ b/src/backend/partaj/core/views/common.py
@@ -67,6 +67,14 @@ class AppView(LoginRequiredMixin, TemplateView):
     template_name = "core/app.html"
 
 
+class LegalMentionsView(TemplateView):
+    """
+    Plain template view for legal mentions.
+    """
+
+    template_name = "core/legal_mentions.html"
+
+
 class IndexView(TemplateView):
     """
     Show a generic content-free view for non-logged in users.

--- a/src/backend/partaj/locale/en/LC_MESSAGES/django.po
+++ b/src/backend/partaj/locale/en/LC_MESSAGES/django.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-01 17:29+0000\n"
-"PO-Revision-Date: 2021-12-01 18:29+0100\n"
+"POT-Creation-Date: 2021-12-22 11:16+0000\n"
+"PO-Revision-Date: 2021-12-22 12:21+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: en\n"
@@ -23,8 +23,8 @@ msgstr "Topic metadata"
 msgid "Topic information"
 msgstr "Topic information"
 
-#: partaj/core/admin.py:39 partaj/core/models/referral.py:771
-#: partaj/core/models/referral.py:830 partaj/core/models/unit.py:52
+#: partaj/core/admin.py:39 partaj/core/models/referral.py:768
+#: partaj/core/models/referral.py:827 partaj/core/models/unit.py:52
 #: partaj/core/models/unit.py:90 partaj/core/models/unit.py:187
 msgid "unit"
 msgstr "unit"
@@ -33,18 +33,19 @@ msgstr "unit"
 msgid "Unit information"
 msgstr "Unit information"
 
-#: partaj/core/admin.py:91 partaj/core/admin.py:121 partaj/core/admin.py:248
+#: partaj/core/admin.py:91 partaj/core/admin.py:121 partaj/core/admin.py:155
+#: partaj/core/admin.py:278
 msgid "Metadata"
 msgstr "Metadata"
 
-#: partaj/core/admin.py:92 partaj/core/admin.py:122
+#: partaj/core/admin.py:92 partaj/core/admin.py:122 partaj/core/admin.py:156
 msgid "Document"
 msgstr "Document"
 
-#: partaj/core/admin.py:107 partaj/core/admin.py:369 partaj/core/admin.py:415
+#: partaj/core/admin.py:107 partaj/core/admin.py:399 partaj/core/admin.py:445
 #: partaj/core/models/attachment.py:85 partaj/core/models/referral.py:161
-#: partaj/core/models/referral.py:744 partaj/core/models/referral.py:777
-#: partaj/core/models/referral.py:812
+#: partaj/core/models/referral.py:741 partaj/core/models/referral.py:774
+#: partaj/core/models/referral.py:809
 #: partaj/core/models/referral_activity.py:68
 #: partaj/core/models/referral_answer.py:60
 #: partaj/core/models/referral_message.py:30
@@ -56,35 +57,40 @@ msgstr "referral"
 msgid "referral answers"
 msgstr "referral answers"
 
-#: partaj/core/admin.py:202
+#: partaj/core/admin.py:171 partaj/core/models/attachment.py:136
+#: partaj/core/models/referral_message.py:53
+msgid "referral message"
+msgstr "referral message"
+
+#: partaj/core/admin.py:232
 msgid "Information"
 msgstr "Information"
 
-#: partaj/core/admin.py:235 partaj/core/admin.py:297 partaj/core/admin.py:342
+#: partaj/core/admin.py:265 partaj/core/admin.py:327 partaj/core/admin.py:372
 msgid "Identification"
 msgstr "Identification"
 
-#: partaj/core/admin.py:237
+#: partaj/core/admin.py:267
 msgid "Timing information"
 msgstr "Timing information"
 
-#: partaj/core/admin.py:249
+#: partaj/core/admin.py:279
 msgid "Referral content"
 msgstr "Referral content"
 
-#: partaj/core/admin.py:276 partaj/core/models/referral.py:74
+#: partaj/core/admin.py:306 partaj/core/models/referral.py:74
 msgid "users"
 msgstr "users"
 
-#: partaj/core/admin.py:299
+#: partaj/core/admin.py:329
 msgid "Activity"
 msgstr "Activity"
 
-#: partaj/core/admin.py:345
+#: partaj/core/admin.py:375
 msgid "Referral answer"
 msgstr "Referral answer"
 
-#: partaj/core/admin.py:407 partaj/core/models/referral_answer.py:84
+#: partaj/core/admin.py:437 partaj/core/models/referral_answer.py:84
 msgid "referral answer"
 msgstr "referral answer"
 
@@ -93,12 +99,12 @@ msgid "Partaj"
 msgstr "Partaj"
 
 #: partaj/core/models/attachment.py:27 partaj/core/models/referral.py:52
-#: partaj/core/models/referral.py:730 partaj/core/models/referral.py:763
-#: partaj/core/models/referral.py:797
+#: partaj/core/models/referral.py:727 partaj/core/models/referral.py:760
+#: partaj/core/models/referral.py:794
 #: partaj/core/models/referral_activity.py:43
 #: partaj/core/models/referral_answer.py:27
-#: partaj/core/models/referral_answer.py:101
-#: partaj/core/models/referral_answer.py:148
+#: partaj/core/models/referral_answer.py:102
+#: partaj/core/models/referral_answer.py:149
 #: partaj/core/models/referral_message.py:20
 #: partaj/core/models/referral_urgencylevel_history.py:17
 #: partaj/core/models/unit.py:28 partaj/core/models/unit.py:74
@@ -111,8 +117,8 @@ msgid "Primary key for the attachment as UUID"
 msgstr "Primary key for the attachment as UUID"
 
 #: partaj/core/models/attachment.py:33 partaj/core/models/referral.py:57
-#: partaj/core/models/referral.py:735 partaj/core/models/referral.py:768
-#: partaj/core/models/referral.py:802
+#: partaj/core/models/referral.py:732 partaj/core/models/referral.py:765
+#: partaj/core/models/referral.py:799
 #: partaj/core/models/referral_activity.py:49
 #: partaj/core/models/referral_answer.py:33
 #: partaj/core/models/referral_message.py:26 partaj/core/models/unit.py:34
@@ -150,11 +156,6 @@ msgstr "referral attachment"
 #: partaj/core/models/attachment.py:119
 msgid "referral answer attachment"
 msgstr "referral answer attachment"
-
-#: partaj/core/models/attachment.py:136
-#: partaj/core/models/referral_message.py:53
-msgid "referral message"
-msgstr "referral message"
 
 #: partaj/core/models/attachment.py:144
 msgid "referral message attachment"
@@ -209,7 +210,7 @@ msgstr "Primary key for the referral"
 msgid "updated at"
 msgstr "updated at"
 
-#: partaj/core/models/referral.py:64 partaj/core/models/referral.py:738
+#: partaj/core/models/referral.py:64 partaj/core/models/referral.py:735
 #: partaj/core/models/referral_message.py:37 partaj/core/models/unit.py:84
 #: partaj/users/models.py:88
 msgid "user"
@@ -308,67 +309,67 @@ msgid "What research did you already perform before the referral?"
 msgstr "What research did you already perform before the referral?"
 
 #: partaj/core/models/referral.py:174 partaj/core/models/referral_answer.py:38
-#: partaj/core/models/referral_answer.py:164
+#: partaj/core/models/referral_answer.py:165
 msgid "state"
 msgstr "state"
 
-#: partaj/core/models/referral.py:731 partaj/core/models/referral.py:764
+#: partaj/core/models/referral.py:728 partaj/core/models/referral.py:761
 msgid "Primary key for the unit assignment"
 msgstr "Primary key for the unit assignment"
 
-#: partaj/core/models/referral.py:739
+#: partaj/core/models/referral.py:736
 msgid "User who is attached to the referral"
 msgstr "User who is attached to the referral"
 
-#: partaj/core/models/referral.py:745
+#: partaj/core/models/referral.py:742
 msgid "Referral the user is attached to"
 msgstr "Referral the user is attached to"
 
-#: partaj/core/models/referral.py:753
+#: partaj/core/models/referral.py:750
 msgid "referral user link"
 msgstr "referral user link"
 
-#: partaj/core/models/referral.py:772
+#: partaj/core/models/referral.py:769
 msgid "Unit who is attached to the referral"
 msgstr "Unit who is attached to the referral"
 
-#: partaj/core/models/referral.py:778
+#: partaj/core/models/referral.py:775
 msgid "Referral the unit is attached to"
 msgstr "Referral the unit is attached to"
 
-#: partaj/core/models/referral.py:786
+#: partaj/core/models/referral.py:783
 msgid "referral unit assignment"
 msgstr "referral unit assignment"
 
-#: partaj/core/models/referral.py:798
+#: partaj/core/models/referral.py:795
 msgid "Primary key for the assignment"
 msgstr "Primary key for the assignment"
 
-#: partaj/core/models/referral.py:806
+#: partaj/core/models/referral.py:803
 msgid "assignee"
 msgstr "assignee"
 
-#: partaj/core/models/referral.py:807
+#: partaj/core/models/referral.py:804
 msgid "User is assigned to work on the referral"
 msgstr "User is assigned to work on the referral"
 
-#: partaj/core/models/referral.py:813
+#: partaj/core/models/referral.py:810
 msgid "Referral the assignee is linked with"
 msgstr "Referral the assignee is linked with"
 
-#: partaj/core/models/referral.py:821 partaj/core/models/referral_answer.py:67
+#: partaj/core/models/referral.py:818 partaj/core/models/referral_answer.py:67
 msgid "created by"
 msgstr "created by"
 
-#: partaj/core/models/referral.py:822
+#: partaj/core/models/referral.py:819
 msgid "User who created the assignment"
 msgstr "User who created the assignment"
 
-#: partaj/core/models/referral.py:831
+#: partaj/core/models/referral.py:828
 msgid "Unit under which the assignment was created"
 msgstr "Unit under which the assignment was created"
 
-#: partaj/core/models/referral.py:842
+#: partaj/core/models/referral.py:839
 msgid "referral assignment"
 msgstr "referral assignment"
 
@@ -417,7 +418,7 @@ msgid "urgency level changed"
 msgstr "urgency level changed"
 
 #: partaj/core/models/referral_activity.py:30
-#: partaj/core/models/referral_answer.py:137
+#: partaj/core/models/referral_answer.py:138
 msgid "validated"
 msgstr "validated"
 
@@ -522,63 +523,63 @@ msgstr "content"
 msgid "Actual content of the answer to the referral"
 msgstr "Actual content of the answer to the referral"
 
-#: partaj/core/models/referral_answer.py:102
+#: partaj/core/models/referral_answer.py:103
 msgid "Primary key for the referral answer validation request as uuid"
 msgstr "Primary key for the referral answer validation request as uuid"
 
-#: partaj/core/models/referral_answer.py:108
+#: partaj/core/models/referral_answer.py:109
 msgid "validator"
 msgstr "validator"
 
-#: partaj/core/models/referral_answer.py:109
+#: partaj/core/models/referral_answer.py:110
 msgid "User who was asked to validate the related answer"
 msgstr "User who was asked to validate the related answer"
 
-#: partaj/core/models/referral_answer.py:116
+#: partaj/core/models/referral_answer.py:117
 msgid "answer"
 msgstr "answer"
 
-#: partaj/core/models/referral_answer.py:117
+#: partaj/core/models/referral_answer.py:118
 msgid "Answer the related user was asked to validate"
 msgstr "Answer the related user was asked to validate"
 
-#: partaj/core/models/referral_answer.py:127
+#: partaj/core/models/referral_answer.py:128
 msgid "referral answer validation request"
 msgstr "referral answer validation request"
 
-#: partaj/core/models/referral_answer.py:135
+#: partaj/core/models/referral_answer.py:136
 msgid "not validated"
 msgstr "not validated"
 
-#: partaj/core/models/referral_answer.py:136
+#: partaj/core/models/referral_answer.py:137
 msgid "pending"
 msgstr "pending"
 
-#: partaj/core/models/referral_answer.py:149
+#: partaj/core/models/referral_answer.py:150
 msgid "Primary key for the referral answer validation response as uuid"
 msgstr "Primary key for the referral answer validation response as uuid"
 
-#: partaj/core/models/referral_answer.py:155
+#: partaj/core/models/referral_answer.py:156
 msgid "validation request"
 msgstr "validation request"
 
-#: partaj/core/models/referral_answer.py:157
+#: partaj/core/models/referral_answer.py:158
 msgid "Validation request for which this response is providing an answer"
 msgstr "Validation request for which this response is providing an answer"
 
-#: partaj/core/models/referral_answer.py:165
+#: partaj/core/models/referral_answer.py:166
 msgid "State of the validation"
 msgstr "State of the validation"
 
-#: partaj/core/models/referral_answer.py:170
+#: partaj/core/models/referral_answer.py:171
 msgid "comment"
 msgstr "comment"
 
-#: partaj/core/models/referral_answer.py:171
+#: partaj/core/models/referral_answer.py:172
 msgid "Comment associated with the validation acceptance or refusal"
 msgstr "Comment associated with the validation acceptance or refusal"
 
-#: partaj/core/models/referral_answer.py:176
+#: partaj/core/models/referral_answer.py:177
 msgid "referral answer validation response"
 msgstr "referral answer validation response"
 
@@ -755,6 +756,15 @@ msgid "Contact us"
 msgstr "Contact us"
 
 #: partaj/core/templates/core/includes/footer.html:21
+#: partaj/core/templates/core/stats.html:8
+msgid "Statistics"
+msgstr "Statistics"
+
+#: partaj/core/templates/core/includes/footer.html:24
+msgid "Legal mentions"
+msgstr "Legal mentions"
+
+#: partaj/core/templates/core/includes/footer.html:27
 msgid "Beta.gouv network"
 msgstr "Beta.gouv network"
 
@@ -765,10 +775,6 @@ msgstr "Documentation"
 #: partaj/core/templates/core/includes/outer_nav.html:26
 msgid "Log in / Sign up"
 msgstr "Log in / Sign up"
-
-#: partaj/core/templates/core/stats.html:8
-msgid "Statistics"
-msgstr "Statistics"
 
 #: partaj/settings.py:268
 msgid "french"

--- a/src/backend/partaj/locale/fr/LC_MESSAGES/django.po
+++ b/src/backend/partaj/locale/fr/LC_MESSAGES/django.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-01 17:29+0000\n"
-"PO-Revision-Date: 2021-12-01 18:30+0100\n"
+"POT-Creation-Date: 2021-12-22 11:20+0000\n"
+"PO-Revision-Date: 2021-12-22 12:21+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -23,8 +23,8 @@ msgstr "Méta-données de la thématique"
 msgid "Topic information"
 msgstr "Informations sur ce thème"
 
-#: partaj/core/admin.py:39 partaj/core/models/referral.py:771
-#: partaj/core/models/referral.py:830 partaj/core/models/unit.py:52
+#: partaj/core/admin.py:39 partaj/core/models/referral.py:768
+#: partaj/core/models/referral.py:827 partaj/core/models/unit.py:52
 #: partaj/core/models/unit.py:90 partaj/core/models/unit.py:187
 msgid "unit"
 msgstr "unité"
@@ -33,18 +33,19 @@ msgstr "unité"
 msgid "Unit information"
 msgstr "Informations sur cette unité"
 
-#: partaj/core/admin.py:91 partaj/core/admin.py:121 partaj/core/admin.py:248
+#: partaj/core/admin.py:91 partaj/core/admin.py:121 partaj/core/admin.py:155
+#: partaj/core/admin.py:278
 msgid "Metadata"
 msgstr "Méta-données"
 
-#: partaj/core/admin.py:92 partaj/core/admin.py:122
+#: partaj/core/admin.py:92 partaj/core/admin.py:122 partaj/core/admin.py:156
 msgid "Document"
 msgstr "Document"
 
-#: partaj/core/admin.py:107 partaj/core/admin.py:369 partaj/core/admin.py:415
+#: partaj/core/admin.py:107 partaj/core/admin.py:399 partaj/core/admin.py:445
 #: partaj/core/models/attachment.py:85 partaj/core/models/referral.py:161
-#: partaj/core/models/referral.py:744 partaj/core/models/referral.py:777
-#: partaj/core/models/referral.py:812
+#: partaj/core/models/referral.py:741 partaj/core/models/referral.py:774
+#: partaj/core/models/referral.py:809
 #: partaj/core/models/referral_activity.py:68
 #: partaj/core/models/referral_answer.py:60
 #: partaj/core/models/referral_message.py:30
@@ -56,35 +57,40 @@ msgstr "saisine"
 msgid "referral answers"
 msgstr "réponses à la saisine"
 
-#: partaj/core/admin.py:202
+#: partaj/core/admin.py:171 partaj/core/models/attachment.py:136
+#: partaj/core/models/referral_message.py:53
+msgid "referral message"
+msgstr "message sur une saisine"
+
+#: partaj/core/admin.py:232
 msgid "Information"
 msgstr "Informations"
 
-#: partaj/core/admin.py:235 partaj/core/admin.py:297 partaj/core/admin.py:342
+#: partaj/core/admin.py:265 partaj/core/admin.py:327 partaj/core/admin.py:372
 msgid "Identification"
 msgstr "Identification"
 
-#: partaj/core/admin.py:237
+#: partaj/core/admin.py:267
 msgid "Timing information"
 msgstr "Informations temporelles"
 
-#: partaj/core/admin.py:249
+#: partaj/core/admin.py:279
 msgid "Referral content"
 msgstr "Contenu de la saisine"
 
-#: partaj/core/admin.py:276 partaj/core/models/referral.py:74
+#: partaj/core/admin.py:306 partaj/core/models/referral.py:74
 msgid "users"
 msgstr "utilisateurs"
 
-#: partaj/core/admin.py:299
+#: partaj/core/admin.py:329
 msgid "Activity"
 msgstr "Activité"
 
-#: partaj/core/admin.py:345
+#: partaj/core/admin.py:375
 msgid "Referral answer"
 msgstr "Réponse à la saisine"
 
-#: partaj/core/admin.py:407 partaj/core/models/referral_answer.py:84
+#: partaj/core/admin.py:437 partaj/core/models/referral_answer.py:84
 msgid "referral answer"
 msgstr "réponse à la saisine"
 
@@ -93,12 +99,12 @@ msgid "Partaj"
 msgstr "Partaj"
 
 #: partaj/core/models/attachment.py:27 partaj/core/models/referral.py:52
-#: partaj/core/models/referral.py:730 partaj/core/models/referral.py:763
-#: partaj/core/models/referral.py:797
+#: partaj/core/models/referral.py:727 partaj/core/models/referral.py:760
+#: partaj/core/models/referral.py:794
 #: partaj/core/models/referral_activity.py:43
 #: partaj/core/models/referral_answer.py:27
-#: partaj/core/models/referral_answer.py:101
-#: partaj/core/models/referral_answer.py:148
+#: partaj/core/models/referral_answer.py:102
+#: partaj/core/models/referral_answer.py:149
 #: partaj/core/models/referral_message.py:20
 #: partaj/core/models/referral_urgencylevel_history.py:17
 #: partaj/core/models/unit.py:28 partaj/core/models/unit.py:74
@@ -111,8 +117,8 @@ msgid "Primary key for the attachment as UUID"
 msgstr "Clef primaire pour le fichier joint"
 
 #: partaj/core/models/attachment.py:33 partaj/core/models/referral.py:57
-#: partaj/core/models/referral.py:735 partaj/core/models/referral.py:768
-#: partaj/core/models/referral.py:802
+#: partaj/core/models/referral.py:732 partaj/core/models/referral.py:765
+#: partaj/core/models/referral.py:799
 #: partaj/core/models/referral_activity.py:49
 #: partaj/core/models/referral_answer.py:33
 #: partaj/core/models/referral_message.py:26 partaj/core/models/unit.py:34
@@ -150,11 +156,6 @@ msgstr "pièce-jointe de saisine"
 #: partaj/core/models/attachment.py:119
 msgid "referral answer attachment"
 msgstr "pièce-jointe de réponse à la saisine"
-
-#: partaj/core/models/attachment.py:136
-#: partaj/core/models/referral_message.py:53
-msgid "referral message"
-msgstr "message sur une saisine"
 
 #: partaj/core/models/attachment.py:144
 msgid "referral message attachment"
@@ -209,7 +210,7 @@ msgstr "Clef primaire pour la saisine"
 msgid "updated at"
 msgstr "mis à jour le"
 
-#: partaj/core/models/referral.py:64 partaj/core/models/referral.py:738
+#: partaj/core/models/referral.py:64 partaj/core/models/referral.py:735
 #: partaj/core/models/referral_message.py:37 partaj/core/models/unit.py:84
 #: partaj/users/models.py:88
 msgid "user"
@@ -310,67 +311,67 @@ msgid "What research did you already perform before the referral?"
 msgstr "Quel travail de recherche avez-vous déjà réalisé avant la saisine ?"
 
 #: partaj/core/models/referral.py:174 partaj/core/models/referral_answer.py:38
-#: partaj/core/models/referral_answer.py:164
+#: partaj/core/models/referral_answer.py:165
 msgid "state"
 msgstr "statut"
 
-#: partaj/core/models/referral.py:731 partaj/core/models/referral.py:764
+#: partaj/core/models/referral.py:728 partaj/core/models/referral.py:761
 msgid "Primary key for the unit assignment"
 msgstr "Clef primaire pour l'affectation d’unité"
 
-#: partaj/core/models/referral.py:739
+#: partaj/core/models/referral.py:736
 msgid "User who is attached to the referral"
 msgstr "Utilisateur attaché à la saisine"
 
-#: partaj/core/models/referral.py:745
+#: partaj/core/models/referral.py:742
 msgid "Referral the user is attached to"
 msgstr "Saisine à laquelle l’utilisateur est lié"
 
-#: partaj/core/models/referral.py:753
+#: partaj/core/models/referral.py:750
 msgid "referral user link"
 msgstr "lien saisine et utilisateur"
 
-#: partaj/core/models/referral.py:772
+#: partaj/core/models/referral.py:769
 msgid "Unit who is attached to the referral"
 msgstr "Unité attachée à la saisine"
 
-#: partaj/core/models/referral.py:778
+#: partaj/core/models/referral.py:775
 msgid "Referral the unit is attached to"
 msgstr "Saisine à laquelle l’unité est liée"
 
-#: partaj/core/models/referral.py:786
+#: partaj/core/models/referral.py:783
 msgid "referral unit assignment"
 msgstr "affectation d’unité à saisine"
 
-#: partaj/core/models/referral.py:798
+#: partaj/core/models/referral.py:795
 msgid "Primary key for the assignment"
 msgstr "Clef primaire pour l'affectation"
 
-#: partaj/core/models/referral.py:806
+#: partaj/core/models/referral.py:803
 msgid "assignee"
 msgstr "membre affecté"
 
-#: partaj/core/models/referral.py:807
+#: partaj/core/models/referral.py:804
 msgid "User is assigned to work on the referral"
 msgstr "Utilisateur affecté à la saisine"
 
-#: partaj/core/models/referral.py:813
+#: partaj/core/models/referral.py:810
 msgid "Referral the assignee is linked with"
 msgstr "Saisine que le membre lié est chargé de gérer"
 
-#: partaj/core/models/referral.py:821 partaj/core/models/referral_answer.py:67
+#: partaj/core/models/referral.py:818 partaj/core/models/referral_answer.py:67
 msgid "created by"
 msgstr "créé(e) par"
 
-#: partaj/core/models/referral.py:822
+#: partaj/core/models/referral.py:819
 msgid "User who created the assignment"
 msgstr "Gérant d'unité qui a créé l'affectation"
 
-#: partaj/core/models/referral.py:831
+#: partaj/core/models/referral.py:828
 msgid "Unit under which the assignment was created"
 msgstr "Unité à travers laquelle cette affectation est créée"
 
-#: partaj/core/models/referral.py:842
+#: partaj/core/models/referral.py:839
 msgid "referral assignment"
 msgstr "affectation de saisine"
 
@@ -419,7 +420,7 @@ msgid "urgency level changed"
 msgstr "changement de niveau d’urgence"
 
 #: partaj/core/models/referral_activity.py:30
-#: partaj/core/models/referral_answer.py:137
+#: partaj/core/models/referral_answer.py:138
 msgid "validated"
 msgstr "validée"
 
@@ -524,63 +525,63 @@ msgstr "contenu"
 msgid "Actual content of the answer to the referral"
 msgstr "Contenu textuel de la réponse à la saisine"
 
-#: partaj/core/models/referral_answer.py:102
+#: partaj/core/models/referral_answer.py:103
 msgid "Primary key for the referral answer validation request as uuid"
 msgstr "Clef primaire pour la demande de validation de réponse"
 
-#: partaj/core/models/referral_answer.py:108
+#: partaj/core/models/referral_answer.py:109
 msgid "validator"
 msgstr "validateur"
 
-#: partaj/core/models/referral_answer.py:109
+#: partaj/core/models/referral_answer.py:110
 msgid "User who was asked to validate the related answer"
 msgstr "Utilisateur à qui est adressée la demande de validation de la réponse"
 
-#: partaj/core/models/referral_answer.py:116
+#: partaj/core/models/referral_answer.py:117
 msgid "answer"
 msgstr "réponse"
 
-#: partaj/core/models/referral_answer.py:117
+#: partaj/core/models/referral_answer.py:118
 msgid "Answer the related user was asked to validate"
 msgstr "Réponse que le validateur doit valider"
 
-#: partaj/core/models/referral_answer.py:127
+#: partaj/core/models/referral_answer.py:128
 msgid "referral answer validation request"
 msgstr "demande de validation de réponse"
 
-#: partaj/core/models/referral_answer.py:135
+#: partaj/core/models/referral_answer.py:136
 msgid "not validated"
 msgstr "non validée"
 
-#: partaj/core/models/referral_answer.py:136
+#: partaj/core/models/referral_answer.py:137
 msgid "pending"
 msgstr "en cours"
 
-#: partaj/core/models/referral_answer.py:149
+#: partaj/core/models/referral_answer.py:150
 msgid "Primary key for the referral answer validation response as uuid"
 msgstr "Clef primaire pour la réponse à la demande de validation d’une réponse"
 
-#: partaj/core/models/referral_answer.py:155
+#: partaj/core/models/referral_answer.py:156
 msgid "validation request"
 msgstr "demande de validation"
 
-#: partaj/core/models/referral_answer.py:157
+#: partaj/core/models/referral_answer.py:158
 msgid "Validation request for which this response is providing an answer"
 msgstr "Demande de validation à laquelle cette réponse correspond"
 
-#: partaj/core/models/referral_answer.py:165
+#: partaj/core/models/referral_answer.py:166
 msgid "State of the validation"
 msgstr "État de la validation"
 
-#: partaj/core/models/referral_answer.py:170
+#: partaj/core/models/referral_answer.py:171
 msgid "comment"
 msgstr "commentaire"
 
-#: partaj/core/models/referral_answer.py:171
+#: partaj/core/models/referral_answer.py:172
 msgid "Comment associated with the validation acceptance or refusal"
 msgstr "Commentaire associé avec la validation ou le refus"
 
-#: partaj/core/models/referral_answer.py:176
+#: partaj/core/models/referral_answer.py:177
 msgid "referral answer validation response"
 msgstr "réponse à une demande de validation de réponse"
 
@@ -761,6 +762,15 @@ msgid "Contact us"
 msgstr "Nous contacter"
 
 #: partaj/core/templates/core/includes/footer.html:21
+#: partaj/core/templates/core/stats.html:8
+msgid "Statistics"
+msgstr "Statistiques"
+
+#: partaj/core/templates/core/includes/footer.html:24
+msgid "Legal mentions"
+msgstr "Mentions légales"
+
+#: partaj/core/templates/core/includes/footer.html:27
 msgid "Beta.gouv network"
 msgstr "Le réseau beta.gouv"
 
@@ -771,10 +781,6 @@ msgstr "Documentation"
 #: partaj/core/templates/core/includes/outer_nav.html:26
 msgid "Log in / Sign up"
 msgstr "Connexion / Inscription"
-
-#: partaj/core/templates/core/stats.html:8
-msgid "Statistics"
-msgstr "Statistiques"
 
 #: partaj/settings.py:268
 msgid "french"

--- a/src/frontend/js/translations/en-US.po
+++ b/src/frontend/js/translations/en-US.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2021-12-08T14:06:07.813Z\n"
+"POT-Creation-Date: 2021-12-22T11:23:35.392Z\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"

--- a/src/frontend/js/translations/fr-FR.po
+++ b/src/frontend/js/translations/fr-FR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2021-12-08T14:06:07.813Z\n"
+"POT-Creation-Date: 2021-12-22T11:23:35.392Z\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"


### PR DESCRIPTION
## Purpose

At the request of our legal team, we're adding a legal mentions page with mentions related to GDPR.

We also added a link to legal mentions in the footer and took this opportunity to also add a link to the stats page there.