### PR TITLE
Implement lite api endpoints for Topics, Units, Users

### DIFF
--- a/src/backend/partaj/core/api/__init__.py
+++ b/src/backend/partaj/core/api/__init__.py
@@ -15,6 +15,7 @@ from .referral_urgency import *
 from .topic import *
 from .topic_lite import *
 from .unit import *
+from .unit_lite import *
 from .unit_membership import *
 from .user import *
 from .user_lite import *

--- a/src/backend/partaj/core/api/__init__.py
+++ b/src/backend/partaj/core/api/__init__.py
@@ -17,3 +17,4 @@ from .topic_lite import *
 from .unit import *
 from .unit_membership import *
 from .user import *
+from .user_lite import *

--- a/src/backend/partaj/core/api/__init__.py
+++ b/src/backend/partaj/core/api/__init__.py
@@ -13,6 +13,7 @@ from .referral_lite import *
 from .referral_message import *
 from .referral_urgency import *
 from .topic import *
+from .topic_lite import *
 from .unit import *
 from .unit_membership import *
 from .user import *

--- a/src/backend/partaj/core/api/common.py
+++ b/src/backend/partaj/core/api/common.py
@@ -1,0 +1,85 @@
+"""
+Generic API utils and mixins that can be reused throughout various ViewSets.
+"""
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from ..indexers import ES_CLIENT
+
+
+class ViewSetMetadata:
+    """
+    "Meta" class intended to be used as an attribute on ViewSets to provide a common set of
+    meta attributes, like the Django `class Meta` on eg. models.
+    """
+
+    def __init__(self, indexer):
+        """
+        Set the required attributes passed from the call site. Currently this only includes
+        the ViewSet's corresponding indexer.
+        """
+        self.indexer = indexer
+
+
+class AutocompleteMixin:
+    """
+    Add a `/{resource}/autocomplete` route on a ViewSet enabling clients to make autocompletion
+    requests using the specific fields & queries in ElasticSearch, as defined in the relevant
+    resource's indexer.
+    """
+
+    # pylint: disable=unused-argument
+    @action(detail=False)
+    def autocomplete(self, request):
+        """
+        Use the "autocomplete" field on the object mapping & objects to provide autocomplete
+        functionality through an API endpoint.
+        """
+        # This mixin is intended to be used on ViewSets. It requires an _indexer attribute holding
+        # the relevant indexer
+        indexer = self._meta.indexer
+
+        # Make sure we return the proper error code instead so the frontend can be debugged
+        # as well if necessary.
+        try:
+            query = request.query_params["query"]
+        except KeyError:
+            return Response(
+                status=400,
+                data={
+                    "errors": [
+                        (
+                            'Missing autocomplete "query" for request '
+                            f"to {self._meta.indexer.index_name}."
+                        )
+                    ]
+                },
+            )
+
+        # Query our specific ES completion field
+        autocomplete_query_response = ES_CLIENT.search(
+            index=indexer.index_name,
+            body={
+                "suggest": {
+                    "objects": {
+                        "prefix": query,
+                        "completion": {"field": "autocomplete"},
+                    }
+                }
+            },
+        )
+
+        # Build a response array from the list of completion options
+        return Response(
+            {
+                "count": len(
+                    autocomplete_query_response["suggest"]["objects"][0]["options"]
+                ),
+                "results": [
+                    option["_source"]["_lite"]
+                    for option in autocomplete_query_response["suggest"]["objects"][0][
+                        "options"
+                    ]
+                ],
+            }
+        )

--- a/src/backend/partaj/core/api/topic_lite.py
+++ b/src/backend/partaj/core/api/topic_lite.py
@@ -1,0 +1,57 @@
+"""
+Topic lite related API endpoints.
+"""
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from ..forms import TopicListQueryForm
+from ..indexers import ES_CLIENT, TopicsIndexer
+from .common import AutocompleteMixin, ViewSetMetadata
+
+
+class TopicLiteViewSet(AutocompleteMixin, GenericViewSet):
+    """
+    API endpoints for lite topics.
+    Uses ElasticSearch to always return lists of lite topics, accessible to all
+    authenticated users.
+    """
+
+    _meta = ViewSetMetadata(indexer=TopicsIndexer)
+
+    permission_classes = [IsAuthenticated]
+
+    def list(self, request, *args, **kwargs):
+        """
+        Handle requests for lists of lite topics (except autocomplete).
+        """
+        form = TopicListQueryForm(data=self.request.query_params)
+        if not form.is_valid():
+            return Response(status=400, data={"errors": form.errors})
+
+        es_query_filters = []
+
+        _id = form.cleaned_data.get("id")
+        if len(_id):
+            es_query_filters += [{"terms": {"_id": _id}}]
+
+        # pylint: disable=unexpected-keyword-arg
+        es_response = ES_CLIENT.search(
+            index=TopicsIndexer.index_name,
+            body={
+                "query": {"bool": {"filter": es_query_filters}},
+                "sort": [{"path": {"order": "asc"}}],
+            },
+            size=form.cleaned_data.get("limit") or 1000,
+        )
+
+        return Response(
+            {
+                "count": len(es_response["hits"]["hits"]),
+                "next": None,
+                "previous": None,
+                "results": [
+                    item["_source"]["_lite"] for item in es_response["hits"]["hits"]
+                ],
+            }
+        )

--- a/src/backend/partaj/core/api/unit_lite.py
+++ b/src/backend/partaj/core/api/unit_lite.py
@@ -1,0 +1,57 @@
+"""
+Topic lite related API endpoints.
+"""
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from ..forms import UnitListQueryForm
+from ..indexers import ES_CLIENT, UnitsIndexer
+from .common import AutocompleteMixin, ViewSetMetadata
+
+
+class UnitLiteViewSet(AutocompleteMixin, GenericViewSet):
+    """
+    API endpoints for lite units.
+    Uses ElasticSearch to always return lists of lite units, accessible to all
+    authenticated users.
+    """
+
+    _meta = ViewSetMetadata(indexer=UnitsIndexer)
+
+    permission_classes = [IsAuthenticated]
+
+    def list(self, request, *args, **kwargs):
+        """
+        Handle requests for lists of lite units (except autocomplete).
+        """
+        form = UnitListQueryForm(data=self.request.query_params)
+        if not form.is_valid():
+            return Response(status=400, data={"errors": form.errors})
+
+        es_query_filters = []
+
+        _id = form.cleaned_data.get("id")
+        if len(_id):
+            es_query_filters += [{"terms": {"_id": _id}}]
+
+        # pylint: disable=unexpected-keyword-arg
+        es_response = ES_CLIENT.search(
+            index=UnitsIndexer.index_name,
+            body={
+                "query": {"bool": {"filter": es_query_filters}},
+                "sort": [{"name": {"order": "asc"}}],
+            },
+            size=form.cleaned_data.get("limit") or 1000,
+        )
+
+        return Response(
+            {
+                "count": len(es_response["hits"]["hits"]),
+                "next": None,
+                "previous": None,
+                "results": [
+                    item["_source"]["_lite"] for item in es_response["hits"]["hits"]
+                ],
+            }
+        )

--- a/src/backend/partaj/core/api/user.py
+++ b/src/backend/partaj/core/api/user.py
@@ -5,10 +5,10 @@ from django.contrib.auth import get_user_model
 from django.db.models import F, Q, Value
 from django.db.models.functions import Concat
 
-from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from ..serializers import UserLiteSerializer, UserSerializer
 from .permissions import NotAllowed
@@ -16,7 +16,7 @@ from .permissions import NotAllowed
 User = get_user_model()
 
 
-class UserViewSet(viewsets.ReadOnlyModelViewSet):
+class UserViewSet(ReadOnlyModelViewSet):
     """
     API endpoints for users.
     """

--- a/src/backend/partaj/core/api/user_lite.py
+++ b/src/backend/partaj/core/api/user_lite.py
@@ -1,0 +1,61 @@
+"""
+User lite related API endpoints.
+"""
+from django.contrib.auth import get_user_model
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from ..forms import UserListQueryForm
+from ..indexers import ES_CLIENT, UsersIndexer
+from .common import AutocompleteMixin, ViewSetMetadata
+
+User = get_user_model()
+
+
+class UserLiteViewSet(AutocompleteMixin, GenericViewSet):
+    """
+    API endpoints for lite users.
+    Uses ElasticSearch to always return lists of lite users, accessible to all
+    authenticated users.
+    """
+
+    _meta = ViewSetMetadata(indexer=UsersIndexer)
+
+    permission_classes = [IsAuthenticated]
+
+    def list(self, request, *args, **kwargs):
+        """
+        Handle requests for lists of lite users (except autocomplete).
+        """
+        form = UserListQueryForm(data=self.request.query_params)
+        if not form.is_valid():
+            return Response(status=400, data={"errors": form.errors})
+
+        es_query_filters = []
+
+        _id = form.cleaned_data.get("id")
+        if len(_id):
+            es_query_filters += [{"terms": {"_id": _id}}]
+
+        # pylint: disable=unexpected-keyword-arg
+        es_response = ES_CLIENT.search(
+            index=UsersIndexer.index_name,
+            body={
+                "query": {"bool": {"filter": es_query_filters}},
+                "sort": [{"full_name": {"order": "asc"}}],
+            },
+            size=form.cleaned_data.get("limit") or 1000,
+        )
+
+        return Response(
+            {
+                "count": len(es_response["hits"]["hits"]),
+                "next": None,
+                "previous": None,
+                "results": [
+                    item["_source"]["_lite"] for item in es_response["hits"]["hits"]
+                ],
+            }
+        )

--- a/src/backend/partaj/core/forms.py
+++ b/src/backend/partaj/core/forms.py
@@ -149,3 +149,13 @@ class TopicListQueryForm(BaseApiListQueryForm):
     id = ArrayField(required=False, base_type=forms.CharField(max_length=50))
     limit = forms.IntegerField(required=False)
     offset = forms.IntegerField(required=False)
+
+
+class UserListQueryForm(BaseApiListQueryForm):
+    """
+    Form to validate query parameters for user lite list requests on the API.
+    """
+
+    id = ArrayField(required=False, base_type=forms.CharField(max_length=50))
+    limit = forms.IntegerField(required=False)
+    offset = forms.IntegerField(required=False)

--- a/src/backend/partaj/core/forms.py
+++ b/src/backend/partaj/core/forms.py
@@ -151,6 +151,16 @@ class TopicListQueryForm(BaseApiListQueryForm):
     offset = forms.IntegerField(required=False)
 
 
+class UnitListQueryForm(BaseApiListQueryForm):
+    """
+    Form to validate query parameters for unit lite list requests on the API.
+    """
+
+    id = ArrayField(required=False, base_type=forms.CharField(max_length=50))
+    limit = forms.IntegerField(required=False)
+    offset = forms.IntegerField(required=False)
+
+
 class UserListQueryForm(BaseApiListQueryForm):
     """
     Form to validate query parameters for user lite list requests on the API.

--- a/src/backend/partaj/core/forms.py
+++ b/src/backend/partaj/core/forms.py
@@ -75,7 +75,33 @@ class ReferralMessageForm(forms.ModelForm):
     )
 
 
-class ReferralListQueryForm(forms.Form):
+class BaseApiListQueryForm(forms.Form):
+    """
+    Common alternative base form class for API List query parameters. Enables support
+    for both single params and lists as values for params.
+    """
+
+    def __init__(self, *args, data=None, **kwargs):
+        """
+        Fix up query parameter data to make lists for ArrayField and single values for
+        other kinds of fields.
+        """
+        # QueryDict/MultiValueDict breaks lists: we need to fix them manually
+        data_fixed = (
+            {
+                key: data.getlist(key)
+                # Only setup lists for form keys that use ArrayField
+                if isinstance(self.base_fields[key], ArrayField) else value[0]
+                for key, value in data.lists()
+            }
+            if data
+            else {}
+        )
+
+        super().__init__(data=data_fixed, *args, **kwargs)
+
+
+class ReferralListQueryForm(BaseApiListQueryForm):
     """
     Form to validate query parameters for referral list requests on the API.
     """
@@ -114,21 +140,12 @@ class ReferralListQueryForm(forms.Form):
     )
     user = ArrayField(required=False, base_type=forms.CharField(max_length=50))
 
-    def __init__(self, *args, data=None, **kwargs):
-        """
-        Fix up query parameter data to make lists for ArrayField and single values for
-        other kinds of fields.
-        """
-        # QueryDict/MultiValueDict breaks lists: we need to fix them manually
-        data_fixed = (
-            {
-                key: data.getlist(key)
-                # Only setup lists for form keys that use ArrayField
-                if isinstance(self.base_fields[key], ArrayField) else value[0]
-                for key, value in data.lists()
-            }
-            if data
-            else {}
-        )
 
-        super().__init__(data=data_fixed, *args, **kwargs)
+class TopicListQueryForm(BaseApiListQueryForm):
+    """
+    Form to validate query parameters for topic lite list requests on the API.
+    """
+
+    id = ArrayField(required=False, base_type=forms.CharField(max_length=50))
+    limit = forms.IntegerField(required=False)
+    offset = forms.IntegerField(required=False)

--- a/src/backend/partaj/core/indexers/__init__.py
+++ b/src/backend/partaj/core/indexers/__init__.py
@@ -5,6 +5,7 @@ Indexing tooling and specialized classes matched with models to index.
 from .common import *
 from .referrals import ReferralsIndexer
 from .topics import TopicsIndexer
+from .units import UnitsIndexer
 from .users import UsersIndexer
 
-ES_INDICES = [ReferralsIndexer, TopicsIndexer, UsersIndexer]
+ES_INDICES = [ReferralsIndexer, TopicsIndexer, UnitsIndexer, UsersIndexer]

--- a/src/backend/partaj/core/indexers/__init__.py
+++ b/src/backend/partaj/core/indexers/__init__.py
@@ -4,5 +4,6 @@ Indexing tooling and specialized classes matched with models to index.
 # flake8: noqa
 from .common import *
 from .referrals import ReferralsIndexer
+from .topics import TopicsIndexer
 
-ES_INDICES = [ReferralsIndexer]
+ES_INDICES = [ReferralsIndexer, TopicsIndexer]

--- a/src/backend/partaj/core/indexers/__init__.py
+++ b/src/backend/partaj/core/indexers/__init__.py
@@ -5,5 +5,6 @@ Indexing tooling and specialized classes matched with models to index.
 from .common import *
 from .referrals import ReferralsIndexer
 from .topics import TopicsIndexer
+from .users import UsersIndexer
 
-ES_INDICES = [ReferralsIndexer, TopicsIndexer]
+ES_INDICES = [ReferralsIndexer, TopicsIndexer, UsersIndexer]

--- a/src/backend/partaj/core/indexers/common.py
+++ b/src/backend/partaj/core/indexers/common.py
@@ -1,8 +1,6 @@
 """
 Helpers and config for indexing, common to all indexing tasks.
 """
-import re
-
 from django.conf import settings
 
 from partaj.core.elasticsearch import (
@@ -97,7 +95,9 @@ def partaj_bulk(actions):
         stats_only=True,
     )
 
+
 DEFAULT_DELIMITERS = [" ", "/", "|"]
+
 
 def slice_string_for_completion(string, delimiters=None):
     """
@@ -114,6 +114,6 @@ def slice_string_for_completion(string, delimiters=None):
 
     for i in range(len(string)):
         if string[len(string) - i - 1] in delimiters:
-            results.append(string[len(string) - i:])
+            results.append(string[len(string) - i :])  # noqa: E203
 
     return results

--- a/src/backend/partaj/core/indexers/common.py
+++ b/src/backend/partaj/core/indexers/common.py
@@ -1,6 +1,8 @@
 """
 Helpers and config for indexing, common to all indexing tasks.
 """
+import re
+
 from django.conf import settings
 
 from partaj.core.elasticsearch import (
@@ -94,3 +96,24 @@ def partaj_bulk(actions):
         client=ES_CLIENT,
         stats_only=True,
     )
+
+DEFAULT_DELIMITERS = [" ", "/", "|"]
+
+def slice_string_for_completion(string, delimiters=None):
+    """
+    Split a string in significant parts for use in completion.
+    Example with " " as a delimiter:
+    "University of Paris 13" => "University of Paris 13", "of Paris 13", "Paris 13", "13"
+
+    This is useful to enable autocompletion starting from any part of a name. If we just use the
+    name directly in the ES completion type, it will only return options that match on the first
+    characters of the whole string, which is not always suitable.
+    """
+    delimiters = delimiters or DEFAULT_DELIMITERS
+    results = [string]
+
+    for i in range(len(string)):
+        if string[len(string) - i - 1] in delimiters:
+            results.append(string[len(string) - i:])
+
+    return results

--- a/src/backend/partaj/core/indexers/topics.py
+++ b/src/backend/partaj/core/indexers/topics.py
@@ -1,0 +1,70 @@
+"""
+Methods and configuration related to the indexing of Topic objects.
+"""
+from django.conf import settings
+
+from ..models import Topic
+from .common import partaj_bulk, slice_string_for_completion
+
+
+class TopicsIndexer:
+    """
+    Makes available the parameters the indexer requires as well as functions to shape
+    objects getting into and out of ElasticSearch.
+    """
+
+    index_name = f"{settings.ELASTICSEARCH['INDICES_PREFIX']}topics"
+    mapping = {
+        "properties": {
+            "autocomplete": {
+                "type": "completion",
+                "analyzer": "simple_diacritics_insensitive",
+            },
+            "path": {"type": "keyword"},
+        }
+    }
+
+    @classmethod
+    def get_es_document_for_topic(cls, topic, index=None, action="index"):
+        """Build an Elasticsearch document from the topic instance."""
+        index = index or cls.index_name
+
+        topic_lite = {
+            "created_at": topic.created_at,
+            "id": topic.id,
+            "name": topic.name,
+            "path": topic.path,
+            "unit_name": topic.unit.name,
+        }
+
+        return {
+            "_id": topic.id,
+            "_index": index,
+            "_op_type": action,
+            "_lite": topic_lite,
+            "autocomplete": slice_string_for_completion(topic.name, [" "]),
+            "path": topic.path,
+        }
+
+    @classmethod
+    def get_es_documents(cls, index=None, action="index"):
+        """
+        Loop on all the topics in database and format them for the ElasticSearch index.
+        """
+        index = index or cls.index_name
+
+        for topic in Topic.objects.filter(is_active=True).select_related("unit"):
+            yield cls.get_es_document_for_topic(topic, index=index, action=action)
+
+    @classmethod
+    def update_topic_document(cls, topic):
+        """
+        Update one document in Elasticsearch, corresponding to one Topic instance.
+        """
+
+        action = cls.get_es_document_for_topic(
+            topic=topic, index=cls.index_name, action="index"
+        )
+
+        # Use bulk to be able to reuse "get_es_document_for_topic" as-is.
+        partaj_bulk([action])

--- a/src/backend/partaj/core/indexers/units.py
+++ b/src/backend/partaj/core/indexers/units.py
@@ -1,0 +1,69 @@
+"""
+Methods and configuration related to the indexing of Unit objects.
+"""
+from django.conf import settings
+
+from ..models import Unit
+from .common import partaj_bulk, slice_string_for_completion
+
+
+class UnitsIndexer:
+    """
+    Makes available the parameters the indexer requires as well as functions to shape
+    objects getting into and out of ElasticSearch.
+    """
+
+    index_name = f"{settings.ELASTICSEARCH['INDICES_PREFIX']}units"
+    mapping = {
+        "properties": {
+            "autocomplete": {
+                "type": "completion",
+                "analyzer": "simple_diacritics_insensitive",
+            },
+            "name": {"type": "keyword"},
+        }
+    }
+
+    @classmethod
+    def get_es_document_for_unit(cls, unit, index=None, action="index"):
+        """Build an Elasticsearch document from the unit instance."""
+        index = index or cls.index_name
+
+        unit_lite = {
+            "id": unit.id,
+            "name": unit.name,
+        }
+
+        return {
+            "_id": unit.id,
+            "_index": index,
+            "_op_type": action,
+            "_lite": unit_lite,
+            "autocomplete": slice_string_for_completion(
+                unit.name, delimiters=[" ", "/"]
+            ),
+            "name": unit.name,
+        }
+
+    @classmethod
+    def get_es_documents(cls, index=None, action="index"):
+        """
+        Loop on all the units in database and format them for the ElasticSearch index.
+        """
+        index = index or cls.index_name
+
+        for unit in Unit.objects.all():
+            yield cls.get_es_document_for_unit(unit, index=index, action=action)
+
+    @classmethod
+    def update_unit_document(cls, unit):
+        """
+        Update one document in Elasticsearch, corresponding to one Unit instance.
+        """
+
+        action = cls.get_es_document_for_unit(
+            unit=unit, index=cls.index_name, action="index"
+        )
+
+        # Use bulk to be able to reuse "get_es_document_for_unit" as-is.
+        partaj_bulk([action])

--- a/src/backend/partaj/core/indexers/users.py
+++ b/src/backend/partaj/core/indexers/users.py
@@ -1,0 +1,71 @@
+"""
+Methods and configuration related to the indexing of User objects.
+"""
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from .common import partaj_bulk, slice_string_for_completion
+
+User = get_user_model()
+
+
+class UsersIndexer:
+    """
+    Makes available the parameters the indexer requires as well as functions to shape
+    objects getting into and out of ElasticSearch.
+    """
+
+    index_name = f"{settings.ELASTICSEARCH['INDICES_PREFIX']}users"
+    mapping = {
+        "properties": {
+            "autocomplete": {
+                "type": "completion",
+                "analyzer": "simple_diacritics_insensitive",
+            },
+            "full_name": {"type": "keyword"},
+        }
+    }
+
+    @classmethod
+    def get_es_document_for_user(cls, user, index=None, action="index"):
+        """Build an Elasticsearch document from the user instance."""
+        index = index or cls.index_name
+
+        user_lite = {
+            "id": user.id,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "unit_name": user.unit_name,
+        }
+
+        return {
+            "_id": user.id,
+            "_index": index,
+            "_op_type": action,
+            "_lite": user_lite,
+            "autocomplete": slice_string_for_completion(user.get_full_name(), [" "]),
+            "full_name": user.get_full_name(),
+        }
+
+    @classmethod
+    def get_es_documents(cls, index=None, action="index"):
+        """
+        Loop on all the users in database and format them for the ElasticSearch index.
+        """
+        index = index or cls.index_name
+
+        for user in User.objects.all():
+            yield cls.get_es_document_for_user(user, index=index, action=action)
+
+    @classmethod
+    def update_user_document(cls, user):
+        """
+        Update one document in Elasticsearch, corresponding to one User instance.
+        """
+
+        action = cls.get_es_document_for_user(
+            user=user, index=cls.index_name, action="index"
+        )
+
+        # Use bulk to be able to reuse "get_es_document_for_user" as-is.
+        partaj_bulk([action])

--- a/src/backend/partaj/core/urls.py
+++ b/src/backend/partaj/core/urls.py
@@ -38,6 +38,7 @@ router.register(r"units", api.UnitViewSet, "units")
 router.register(r"unitmemberships", api.UnitMembershipViewSet, "unitmemberships")
 router.register(r"urgencies", api.ReferralUrgencyViewSet, "urgencies")
 router.register(r"users", api.UserViewSet, "users")
+router.register(r"userlites", api.UserLiteViewSet, "users")
 
 urlpatterns = [
     # DRF API router

--- a/src/backend/partaj/core/urls.py
+++ b/src/backend/partaj/core/urls.py
@@ -35,6 +35,7 @@ router.register(r"referralmessages", api.ReferralMessageViewSet, "referralmessag
 router.register(r"topics", api.TopicViewSet, "topics")
 router.register(r"topiclites", api.TopicLiteViewSet, "topicslites")
 router.register(r"units", api.UnitViewSet, "units")
+router.register(r"unitlites", api.UnitLiteViewSet, "units")
 router.register(r"unitmemberships", api.UnitMembershipViewSet, "unitmemberships")
 router.register(r"urgencies", api.ReferralUrgencyViewSet, "urgencies")
 router.register(r"users", api.UserViewSet, "users")

--- a/src/backend/partaj/core/urls.py
+++ b/src/backend/partaj/core/urls.py
@@ -33,6 +33,7 @@ router.register(
 )
 router.register(r"referralmessages", api.ReferralMessageViewSet, "referralmessages")
 router.register(r"topics", api.TopicViewSet, "topics")
+router.register(r"topiclites", api.TopicLiteViewSet, "topicslites")
 router.register(r"units", api.UnitViewSet, "units")
 router.register(r"unitmemberships", api.UnitMembershipViewSet, "unitmemberships")
 router.register(r"urgencies", api.ReferralUrgencyViewSet, "urgencies")

--- a/src/backend/tests/partaj/core/test_api_referrallite_sorting.py
+++ b/src/backend/tests/partaj/core/test_api_referrallite_sorting.py
@@ -303,7 +303,7 @@ class ReferralLiteApiTestCase(TestCase):
         """
         Referrals can be sorted by ascending requesters (alphabetically).
         """
-        user = factories.UserFactory()
+        user = factories.UserFactory(unit_name="z_unite")
         referrals = [
             factories.ReferralFactory(
                 state=models.ReferralState.RECEIVED,

--- a/src/backend/tests/partaj/core/test_api_topiclite.py
+++ b/src/backend/tests/partaj/core/test_api_topiclite.py
@@ -1,0 +1,150 @@
+from django.test import TestCase
+
+from rest_framework.authtoken.models import Token
+
+from partaj.core import factories
+from partaj.core.elasticsearch import (
+    ElasticsearchClientCompat7to6,
+    ElasticsearchIndicesClientCompat7to6,
+)
+from partaj.core.indexers import ANALYSIS_SETTINGS, TopicsIndexer
+from partaj.core.index_manager import partaj_bulk
+
+
+ES_CLIENT = ElasticsearchClientCompat7to6(["elasticsearch"])
+ES_INDICES_CLIENT = ElasticsearchIndicesClientCompat7to6(ES_CLIENT)
+
+
+class TopicApiTestCase(TestCase):
+    """
+    Test API routes and actions related to Topic endpoints.
+    """
+
+    @staticmethod
+    def setup_elasticsearch():
+        """
+        Set up ES indices and their settings with existing instances.
+        """
+        # Delete any existing indices so we get a clean slate
+        ES_INDICES_CLIENT.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        ES_INDICES_CLIENT.create(index=TopicsIndexer.index_name)
+        ES_INDICES_CLIENT.close(index=TopicsIndexer.index_name)
+        ES_INDICES_CLIENT.put_settings(
+            body=ANALYSIS_SETTINGS, index=TopicsIndexer.index_name
+        )
+        ES_INDICES_CLIENT.open(index=TopicsIndexer.index_name)
+
+        # Use the default topics mapping from the Indexer
+        ES_INDICES_CLIENT.put_mapping(
+            body=TopicsIndexer.mapping, index=TopicsIndexer.index_name
+        )
+
+        # Actually insert our topics in the index
+        partaj_bulk(actions=TopicsIndexer.get_es_documents())
+        ES_INDICES_CLIENT.refresh()
+
+    # LIST TESTS
+    def test_list_topiclites_from_anonymous_user(self):
+        """
+        Anonymous users cannot list existing topics through the topic lite list endpoint.
+        """
+        root_topics = [
+            factories.TopicFactory(name="First root topic"),
+            factories.TopicFactory(name="Second root topic"),
+        ]
+        factories.TopicFactory(is_active=False)
+        factories.TopicFactory(name="Child topic", parent=root_topics[0])
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/topiclites/?limit=999",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_topiclites_from_logged_in_user(self):
+        """
+        Logged-in users can list existing topics through the topic lite list endpoint.
+        """
+        user = factories.UserFactory()
+        root_topics = [
+            factories.TopicFactory(name="First root topic"),
+            factories.TopicFactory(name="Second root topic"),
+        ]
+        factories.TopicFactory(is_active=False)
+        factories.TopicFactory(name="Child topic", parent=root_topics[0])
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/topiclites/?limit=999",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 3)
+        self.assertEqual(response.json()["results"][0]["name"], "First root topic")
+        self.assertEqual(response.json()["results"][1]["name"], "Child topic")
+        self.assertEqual(response.json()["results"][2]["name"], "Second root topic")
+
+    def test_list_topiclites_by_id_from_logged_in_user(self):
+        """
+        Logged-in users can filter topics by id through the topic lite list endpoint.
+        """
+        user = factories.UserFactory()
+        root_topics = [
+            factories.TopicFactory(name="First root topic"),
+            factories.TopicFactory(name="Second root topic"),
+        ]
+        factories.TopicFactory(is_active=False)
+        child_topic = factories.TopicFactory(name="Child topic", parent=root_topics[0])
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            f"/api/topiclites/?limit=999&id={str(root_topics[0].id)}&id={str(child_topic.id)}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["results"][0]["name"], "First root topic")
+        self.assertEqual(response.json()["results"][1]["name"], "Child topic")
+
+    # AUTOCOMPLETE TESTS
+    def test_autocomplete_topiclites_from_anonymous_user(self):
+        """
+        Anonymous users cannot make autocompletion search requests for existing topics.
+        """
+        root_topics = [
+            factories.TopicFactory(name="First root topic"),
+            factories.TopicFactory(name="Second root topic"),
+        ]
+        factories.TopicFactory(is_active=False)
+        factories.TopicFactory(name="Child topic", parent=root_topics[0])
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/topiclites/autocomplete/?limit=999&query=root",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_autocomplete_topiclites_from_logged_in_user(self):
+        """
+        Logged-in users can make autocompletion search requests for existing topics.
+        """
+        user = factories.UserFactory()
+        root_topics = [
+            factories.TopicFactory(name="First root topic"),
+            factories.TopicFactory(name="Second root topic"),
+        ]
+        factories.TopicFactory(is_active=False)
+        factories.TopicFactory(name="Child topic", parent=root_topics[0])
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/topiclites/autocomplete/?limit=999&query=second",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["name"], "Second root topic")

--- a/src/backend/tests/partaj/core/test_api_unitlite.py
+++ b/src/backend/tests/partaj/core/test_api_unitlite.py
@@ -1,0 +1,134 @@
+from django.test import TestCase
+
+from rest_framework.authtoken.models import Token
+
+from partaj.core import factories
+from partaj.core.elasticsearch import (
+    ElasticsearchClientCompat7to6,
+    ElasticsearchIndicesClientCompat7to6,
+)
+from partaj.core.indexers import ANALYSIS_SETTINGS, UnitsIndexer
+from partaj.core.index_manager import partaj_bulk
+
+ES_CLIENT = ElasticsearchClientCompat7to6(["elasticsearch"])
+ES_INDICES_CLIENT = ElasticsearchIndicesClientCompat7to6(ES_CLIENT)
+
+
+class UnitApiTestCase(TestCase):
+    """
+    Test API routes and actions related to Unit endpoints.
+    """
+
+    @staticmethod
+    def setup_elasticsearch():
+        """
+        Set up ES indices and their settings with existing instances.
+        """
+        # Delete any existing indices so we get a clean slate
+        ES_INDICES_CLIENT.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        ES_INDICES_CLIENT.create(index="partaj_units")
+        ES_INDICES_CLIENT.close(index="partaj_units")
+        ES_INDICES_CLIENT.put_settings(body=ANALYSIS_SETTINGS, index="partaj_units")
+        ES_INDICES_CLIENT.open(index="partaj_units")
+
+        # Use the default units mapping from the Indexer
+        ES_INDICES_CLIENT.put_mapping(body=UnitsIndexer.mapping, index="partaj_units")
+
+        # Actually insert our units in the index
+        partaj_bulk(actions=UnitsIndexer.get_es_documents())
+        ES_INDICES_CLIENT.refresh()
+
+    # LIST TESTS
+    def test_list_unitlites_from_anonymous_user(self):
+        """
+        Anonymous users cannot list existing units through the unit lite list endpoint.
+        """
+        factories.UnitFactory(name="SG/DAJ/AJYX")
+        factories.UnitFactory(name="AJYX4")
+        factories.UnitFactory(name="SG/SNUM")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/unitlites/?limit=999",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_unitlites_from_logged_in_user(self):
+        """
+        Logged-in users can list existing units through the unit lite list endpoint.
+        """
+        user = factories.UserFactory()
+
+        factories.UnitFactory(name="SG/DAJ/AJYX")
+        factories.UnitFactory(name="AJYX4")
+        factories.UnitFactory(name="SG/SNUM")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/unitlites/?limit=999",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 3)
+        self.assertEqual(response.json()["results"][0]["name"], "AJYX4")
+        self.assertEqual(response.json()["results"][1]["name"], "SG/DAJ/AJYX")
+        self.assertEqual(response.json()["results"][2]["name"], "SG/SNUM")
+
+    def test_list_unitlites_by_id_from_logged_in_user(self):
+        """
+        Logged-in users can filter units by id through the unit lite list endpoint.
+        """
+        user = factories.UserFactory()
+
+        unit_1 = factories.UnitFactory(name="SG/DAJ/AJYX")
+        unit_2 = factories.UnitFactory(name="AJYX4")
+        factories.UnitFactory(name="SG/SNUM")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            f"/api/unitlites/?limit=999&id={str(unit_1.id)}&id={str(unit_2.id)}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["results"][0]["name"], "AJYX4")
+        self.assertEqual(response.json()["results"][1]["name"], "SG/DAJ/AJYX")
+
+    # AUTOCOMPLETE TESTS
+    def test_autocomplete_units_from_anonymous_user(self):
+        """
+        Anonymous users cannot make autocompletion search requests for units.
+        """
+        factories.UnitFactory(name="SG/DAJ/AJYX")
+        factories.UnitFactory(name="AJYX4")
+        factories.UnitFactory(name="SG/SNUM")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/unitlites/autocomplete/?limit=999&query=AJYX",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_autocomplete_units_from_logged_in_user(self):
+        """
+        Logged-in users can make autocompletion search requests for units.
+        """
+        user = factories.UserFactory()
+
+        factories.UnitFactory(name="SG/DAJ/AJYX")
+        factories.UnitFactory(name="AJYX4")
+        factories.UnitFactory(name="SG/SNUM")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/unitlites/autocomplete/?limit=999&query=AJYX",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["results"][0]["name"], "SG/DAJ/AJYX")
+        self.assertEqual(response.json()["results"][1]["name"], "AJYX4")

--- a/src/backend/tests/partaj/core/test_api_userlite.py
+++ b/src/backend/tests/partaj/core/test_api_userlite.py
@@ -1,0 +1,145 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.authtoken.models import Token
+
+from partaj.core import factories
+from partaj.core.elasticsearch import (
+    ElasticsearchClientCompat7to6,
+    ElasticsearchIndicesClientCompat7to6,
+)
+from partaj.core.indexers import ANALYSIS_SETTINGS, UsersIndexer
+from partaj.core.index_manager import partaj_bulk
+
+User = get_user_model()
+
+ES_CLIENT = ElasticsearchClientCompat7to6(["elasticsearch"])
+ES_INDICES_CLIENT = ElasticsearchIndicesClientCompat7to6(ES_CLIENT)
+
+
+class UserApiTestCase(TestCase):
+    """
+    Test API routes and actions related to User endpoints.
+    """
+
+    @staticmethod
+    def setup_elasticsearch():
+        """
+        Set up ES indices and their settings with existing instances.
+        """
+        # Delete any existing indices so we get a clean slate
+        ES_INDICES_CLIENT.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        ES_INDICES_CLIENT.create(index=UsersIndexer().index_name)
+        ES_INDICES_CLIENT.close(index=UsersIndexer().index_name)
+        ES_INDICES_CLIENT.put_settings(
+            body=ANALYSIS_SETTINGS, index=UsersIndexer().index_name
+        )
+        ES_INDICES_CLIENT.open(index=UsersIndexer().index_name)
+
+        # Use the default users mapping from the Indexer
+        ES_INDICES_CLIENT.put_mapping(
+            body=UsersIndexer.mapping, index=UsersIndexer().index_name
+        )
+
+        # Actually insert our users in the index
+        partaj_bulk(actions=UsersIndexer.get_es_documents())
+        ES_INDICES_CLIENT.refresh()
+
+    # LIST TESTS
+    def test_list_userlites_from_anonymous_user(self):
+        """
+        Anonymous users cannot list existing users through the user lite list endpoint.
+        """
+        factories.UserFactory(first_name="Pierrick", last_name="Dupont")
+        factories.UserFactory(first_name="Jean Pierre", last_name="Duchêne")
+        factories.UserFactory(first_name="Henri", last_name="Pierret")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/userlites/?limit=999",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_userlites_from_logged_in_user(self):
+        """
+        Logged-in users can list existing users through the user lite list endpoint.
+        """
+        # Delete the admin user so we get a clean slate for our test
+        User.objects.first().delete()
+        current_user = factories.UserFactory(first_name="Jean", last_name="Doe")
+
+        user_1 = factories.UserFactory(first_name="Pierrick", last_name="Dupont")
+        user_2 = factories.UserFactory(first_name="Jean Pierre", last_name="Duchêne")
+        user_3 = factories.UserFactory(first_name="Henri", last_name="Pierret")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/userlites/?limit=999",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=current_user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 4)
+        self.assertEqual(response.json()["results"][0]["id"], str(user_3.id))
+        self.assertEqual(response.json()["results"][1]["id"], str(current_user.id))
+        self.assertEqual(response.json()["results"][2]["id"], str(user_2.id))
+        self.assertEqual(response.json()["results"][3]["id"], str(user_1.id))
+
+    def test_list_userlites_by_id_from_logged_in_user(self):
+        """
+        Logged-in users can filter users by id through the user lite list endpoint.
+        """
+        # Delete the admin user so we get a clean slate for our test
+        User.objects.first().delete()
+        current_user = factories.UserFactory(first_name="Jean", last_name="Doe")
+
+        user_1 = factories.UserFactory(first_name="Pierrick", last_name="Dupont")
+        factories.UserFactory(first_name="Jean Pierre", last_name="Duchêne")
+        user_3 = factories.UserFactory(first_name="Henri", last_name="Pierret")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            f"/api/userlites/?limit=999&id={user_1.id}&id={user_3.id}",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=current_user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["results"][0]["id"], str(user_3.id))
+        self.assertEqual(response.json()["results"][1]["id"], str(user_1.id))
+
+    # AUTOCOMPLETE TESTS
+    def test_autocomplete_users_from_anonymous_user(self):
+        """
+        Anonymous users cannot make autocompletion search requests for users.
+        """
+        factories.UserFactory(first_name="Pierrick", last_name="Dupont")
+        factories.UserFactory(first_name="Jean Pierre", last_name="Duchêne")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/userlites/autocomplete/?limit=999&query=pierr",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_autocomplete_users_from_logged_in_user(self):
+        """
+        Logged-in users can make autocompletion search requests for users.
+        """
+        current_user = factories.UserFactory(first_name="Jean", last_name="Doe")
+
+        user_1 = factories.UserFactory(first_name="Pierrick", last_name="Dupont")
+        user_2 = factories.UserFactory(first_name="Jean Pierre", last_name="Duchêne")
+        user_3 = factories.UserFactory(first_name="Henri", last_name="Pierret")
+
+        self.setup_elasticsearch()
+        response = self.client.get(
+            "/api/userlites/autocomplete/?limit=999&query=pierr",
+            HTTP_AUTHORIZATION=f"Token {Token.objects.get_or_create(user=current_user)[0]}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 3)
+        self.assertEqual(response.json()["results"][0]["id"], str(user_2.id))
+        self.assertEqual(response.json()["results"][1]["id"], str(user_3.id))
+        self.assertEqual(response.json()["results"][2]["id"], str(user_1.id))

--- a/src/backend/tests/partaj/core/test_indexers_common.py
+++ b/src/backend/tests/partaj/core/test_indexers_common.py
@@ -1,0 +1,36 @@
+"""
+Tests for common helpers for indexers.
+"""
+from partaj.core.indexers.common import slice_string_for_completion
+
+from django.test import TestCase
+
+
+class IndexersCommonTestCase(TestCase):
+    """
+    Test utilities from the indexers common file.
+    """
+
+    def test_slice_string_for_completion(self):
+        """
+        Slice string method produces all substrings from the end of the passed
+        string that start right after a delimiter.
+        This is useful to populate an index field to be used for autocompletion,
+        when we want that autocompletion to support starting at arbitrary points
+        in the source string.
+        """
+
+        self.assertEqual(
+            slice_string_for_completion("example string", [" "]),
+            ["example string", "string"],
+        )
+
+        self.assertEqual(
+            slice_string_for_completion("SG/DAJ/AJYX/AJYX9", ["/"]),
+            ["SG/DAJ/AJYX/AJYX9", "AJYX9", "AJYX/AJYX9", "DAJ/AJYX/AJYX9"]
+        )
+
+        self.assertEqual(
+            slice_string_for_completion("exam/ple str|ing", [" ", "|", "/"]),
+            ["exam/ple str|ing", "ing", "str|ing", "ple str|ing"]
+        )


### PR DESCRIPTION
## Purpose

To improve filtering on lists of referrals (and power up other features), we need to create new endpoints to get lists of objects related to referrals quickly based on various kinds of parameters. 

## Proposal

To that end, we're setting up new viewsets that return "lite" objects that are lighter and don't require authorization to view.

As we add autocomplete based filters to the general purpose search field in <ReferralTable />, we also need to enable autocompletion for the filter values we're adding in the search field.

We built it with a reusable mixin as it functions the same for all those kinds of objects.
