### PR TITLE
Autocomplete referral search

### DIFF
--- a/src/frontend/css/components/autosuggest.css
+++ b/src/frontend/css/components/autosuggest.css
@@ -37,3 +37,24 @@
     }
   }
 }
+
+.react-autosuggest-with-sections {
+  .react-autosuggest {
+    &__suggestions-container--open {
+      @apply border-gray-300 pb-4;
+      min-width: 25rem;
+    }
+
+    &__section-container {
+      @apply mt-4 pl-4;
+    }
+
+    &__section-title {
+      @apply text-gray-500 font-medium mb-2;
+    }
+
+    &__suggestions-list {
+      @apply ml-2 rounded-none shadow-none;
+    }
+  }
+}

--- a/src/frontend/js/components/ReferralTable/EnabledFiltersList.tsx
+++ b/src/frontend/js/components/ReferralTable/EnabledFiltersList.tsx
@@ -1,0 +1,308 @@
+import React, { Dispatch, Fragment, SetStateAction } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { useQueries, UseQueryResult } from 'react-query';
+import { useUIDSeed } from 'react-uid';
+
+import { appData } from 'appData';
+import { GenericErrorMessage } from 'components/GenericErrorMessage';
+import { Spinner } from 'components/Spinner';
+import { fetchList } from 'data/fetchList';
+import { APIList, TopicLite, UnitLite, UserLite } from 'types';
+import { referralStateMessages } from 'utils/sharedMessages';
+import { getUserFullname } from 'utils/user';
+import { sharedMessages } from './sharedMessages';
+import { FilterColumns, FiltersDict } from './types';
+
+const messages = defineMessages({
+  dueDateFilter: {
+    defaultMessage:
+      'Between {due_date_after, date, short} and {due_date_before , date, short}',
+    description: 'Text for the filter label for due date filtering.',
+    id: 'components.ReferralTable.EnabledFiltersList.dueDateFilter',
+  },
+  loadingActiveFilters: {
+    defaultMessage: 'Loading active filters...',
+    description:
+      'Accessible alt text for the spinner while loading human readable filter values.',
+    id: 'components.ReferralTable.EnabledFiltersList.loadingActiveFilters',
+  },
+  removeFilter: {
+    defaultMessage: 'Remove filter',
+    description:
+      'Accessible title for the button to remove the related filter.',
+    id: 'components.ReferralTable.EnabledFiltersList.removeFilter',
+  },
+});
+
+interface EnabledFiltersListProps {
+  filters: FiltersDict;
+  setFilters: Dispatch<SetStateAction<FiltersDict>>;
+}
+
+export const EnabledFiltersList = ({
+  filters,
+  setFilters,
+}: EnabledFiltersListProps) => {
+  const seed = useUIDSeed();
+
+  const filterQueriesArgs = [];
+  if (filters[FilterColumns.TOPIC]?.length) {
+    filterQueriesArgs.push({
+      queryKey: ['topiclites', { id: filters[FilterColumns.TOPIC] }] as const,
+      queryFn: fetchList as any,
+    });
+  }
+  if (filters[FilterColumns.UNIT]?.length) {
+    filterQueriesArgs.push({
+      queryKey: ['unitlites', { id: filters[FilterColumns.UNIT] }] as const,
+      queryFn: fetchList as any,
+    });
+  }
+  if (filters[FilterColumns.ASSIGNEE]?.length) {
+    filterQueriesArgs.push({
+      queryKey: ['userlites', { id: filters[FilterColumns.ASSIGNEE] }] as const,
+      queryFn: fetchList as any,
+    });
+  }
+  const filterQueries = useQueries(filterQueriesArgs) as UseQueryResult<
+    APIList<TopicLite | UnitLite | UserLite>
+  >[];
+  const allStatuses = filterQueries.map((query) => query.status);
+  if (allStatuses.includes('error')) {
+    return <GenericErrorMessage />;
+  }
+  if (allStatuses.includes('idle') || allStatuses.includes('loading')) {
+    return (
+      <Spinner>
+        <FormattedMessage {...messages.loadingActiveFilters} />
+      </Spinner>
+    );
+  }
+
+  const allResults = filterQueriesArgs.reduce((acc, args, index) => {
+    return {
+      ...acc,
+      [args.queryKey[0]]: filterQueries[index].data!.results.reduce(
+        (innerAcc, item) => {
+          return { ...innerAcc, [item.id]: item };
+        },
+        {},
+      ),
+    };
+  }, {}) as {
+    topiclites: { [key: string]: TopicLite };
+    unitlites: { [key: string]: UnitLite };
+    userlites: { [key: string]: UserLite };
+  };
+
+  return (
+    <div className="flex flex-row items-center flex-wrap gap-2">
+      {filters[FilterColumns.DUE_DATE] ? (
+        <div className="tag tag-blue">
+          <FormattedMessage {...sharedMessages[FilterColumns.DUE_DATE]} />:{' '}
+          <FormattedMessage
+            {...messages.dueDateFilter}
+            values={filters[FilterColumns.DUE_DATE]}
+          />
+          <button
+            onClick={() =>
+              setFilters((existingFilters) => ({
+                ...existingFilters,
+                [FilterColumns.DUE_DATE]: undefined,
+              }))
+            }
+            aria-labelledby={seed(FilterColumns.DUE_DATE)}
+          >
+            <svg role="img" className="w-5 h-5 -mr-2 fill-current">
+              <use xlinkHref={`${appData.assets.icons}#icon-cross`} />
+              <title id={seed(FilterColumns.DUE_DATE)}>
+                <FormattedMessage {...messages.removeFilter} />
+              </title>
+            </svg>
+          </button>
+        </div>
+      ) : null}
+
+      {filters[FilterColumns.STATE] ? (
+        <Fragment>
+          {filters[FilterColumns.STATE]!.map((state) => (
+            <div className="tag tag-blue" key={state}>
+              <FormattedMessage {...sharedMessages[FilterColumns.STATE]} />:{' '}
+              <FormattedMessage {...referralStateMessages[state]} />
+              <button
+                onClick={() =>
+                  setFilters((existingFilters) => ({
+                    ...existingFilters,
+                    [FilterColumns.STATE]:
+                      existingFilters[FilterColumns.STATE]!.length === 1
+                        ? undefined
+                        : existingFilters[FilterColumns.STATE]!.filter(
+                            (selectedState) => selectedState !== state,
+                          ),
+                  }))
+                }
+                aria-labelledby={seed(`${FilterColumns.STATE} - ${state}`)}
+              >
+                <svg role="img" className="w-5 h-5 -mr-2 fill-current">
+                  <use xlinkHref={`${appData.assets.icons}#icon-cross`} />
+                  <title id={seed(`${FilterColumns.STATE} - ${state}`)}>
+                    <FormattedMessage {...messages.removeFilter} />
+                  </title>
+                </svg>
+              </button>
+            </div>
+          ))}
+        </Fragment>
+      ) : null}
+
+      {filters[FilterColumns.USER_UNIT_NAME] ? (
+        <Fragment>
+          {filters[FilterColumns.USER_UNIT_NAME]!.map((unitName) => (
+            <div className="tag tag-blue" key={unitName}>
+              <FormattedMessage
+                {...sharedMessages[FilterColumns.USER_UNIT_NAME]}
+              />
+              {unitName}
+              <button
+                onClick={() =>
+                  setFilters((existingFilters) => ({
+                    ...existingFilters,
+                    [FilterColumns.USER_UNIT_NAME]:
+                      existingFilters[FilterColumns.USER_UNIT_NAME]!.length ===
+                      1
+                        ? undefined
+                        : existingFilters[FilterColumns.USER_UNIT_NAME]!.filter(
+                            (selectedUnit) => selectedUnit !== unitName,
+                          ),
+                  }))
+                }
+                aria-labelledby={seed(
+                  `${FilterColumns.USER_UNIT_NAME} - ${unitName}}`,
+                )}
+              >
+                <svg role="img" className="w-5 h-5 -mr-2 fill-current">
+                  <use xlinkHref={`${appData.assets.icons}#icon-cross`} />
+                  <title
+                    id={seed(`${FilterColumns.USER_UNIT_NAME} - ${unitName}`)}
+                  >
+                    <FormattedMessage {...messages.removeFilter} />
+                  </title>
+                </svg>
+              </button>
+            </div>
+          ))}
+        </Fragment>
+      ) : null}
+
+      {filters[FilterColumns.ASSIGNEE] ? (
+        <Fragment>
+          {filters[FilterColumns.ASSIGNEE]!.map((user) => (
+            <div className="tag tag-blue" key={user}>
+              <FormattedMessage {...sharedMessages[FilterColumns.ASSIGNEE]} />:{' '}
+              {getUserFullname(allResults.userlites[user])}
+              <button
+                onClick={() =>
+                  setFilters((existingFilters) => ({
+                    ...existingFilters,
+                    [FilterColumns.ASSIGNEE]:
+                      existingFilters[FilterColumns.ASSIGNEE]!.length === 1
+                        ? undefined
+                        : existingFilters[FilterColumns.ASSIGNEE]!.filter(
+                            (selectedUser) => selectedUser !== user,
+                          ),
+                  }))
+                }
+                aria-labelledby={seed(`${FilterColumns.ASSIGNEE} - ${user}}`)}
+              >
+                <svg role="img" className="w-5 h-5 -mr-2 fill-current">
+                  <use xlinkHref={`${appData.assets.icons}#icon-cross`} />
+                  <title
+                    id={seed(
+                      `${FilterColumns.ASSIGNEE} - ${getUserFullname(
+                        allResults.userlites[user],
+                      )}`,
+                    )}
+                  >
+                    <FormattedMessage {...messages.removeFilter} />
+                  </title>
+                </svg>
+              </button>
+            </div>
+          ))}
+        </Fragment>
+      ) : null}
+
+      {filters[FilterColumns.UNIT] ? (
+        <Fragment>
+          {filters[FilterColumns.UNIT]!.map((unit) => (
+            <div className="tag tag-blue" key={unit}>
+              <FormattedMessage {...sharedMessages[FilterColumns.UNIT]} />:{' '}
+              {allResults.unitlites[unit].name}
+              <button
+                onClick={() =>
+                  setFilters((existingFilters) => ({
+                    ...existingFilters,
+                    [FilterColumns.UNIT]:
+                      existingFilters[FilterColumns.UNIT]!.length === 1
+                        ? undefined
+                        : existingFilters[FilterColumns.UNIT]!.filter(
+                            (selectedUnit) => selectedUnit !== unit,
+                          ),
+                  }))
+                }
+                aria-labelledby={seed(`${FilterColumns.UNIT} - ${unit}}`)}
+              >
+                <svg role="img" className="w-5 h-5 -mr-2 fill-current">
+                  <use xlinkHref={`${appData.assets.icons}#icon-cross`} />
+                  <title
+                    id={seed(
+                      `${FilterColumns.UNIT} - ${allResults.unitlites[unit].name}`,
+                    )}
+                  >
+                    <FormattedMessage {...messages.removeFilter} />
+                  </title>
+                </svg>
+              </button>
+            </div>
+          ))}
+        </Fragment>
+      ) : null}
+
+      {filters[FilterColumns.TOPIC] ? (
+        <Fragment>
+          {filters[FilterColumns.TOPIC]!.map((topic) => (
+            <div className="tag tag-blue" key={topic}>
+              <FormattedMessage {...sharedMessages[FilterColumns.TOPIC]} />:{' '}
+              {allResults.topiclites[topic].name}
+              <button
+                onClick={() =>
+                  setFilters((existingFilters) => ({
+                    ...existingFilters,
+                    [FilterColumns.TOPIC]:
+                      existingFilters[FilterColumns.TOPIC]!.length === 1
+                        ? undefined
+                        : existingFilters[FilterColumns.TOPIC]!.filter(
+                            (selectedTopic) => selectedTopic !== topic,
+                          ),
+                  }))
+                }
+                aria-labelledby={seed(`${FilterColumns.TOPIC} - ${topic}}`)}
+              >
+                <svg role="img" className="w-5 h-5 -mr-2 fill-current">
+                  <use xlinkHref={`${appData.assets.icons}#icon-cross`} />
+                  <title
+                    id={seed(
+                      `${FilterColumns.TOPIC} - ${allResults.topiclites[topic].name}`,
+                    )}
+                  >
+                    <FormattedMessage {...messages.removeFilter} />
+                  </title>
+                </svg>
+              </button>
+            </div>
+          ))}
+        </Fragment>
+      ) : null}
+    </div>
+  );
+};

--- a/src/frontend/js/components/ReferralTable/Input.tsx
+++ b/src/frontend/js/components/ReferralTable/Input.tsx
@@ -1,9 +1,26 @@
+import * as Sentry from '@sentry/react';
 import debounce from 'lodash-es/debounce';
+import { stringify } from 'query-string';
 import React, { Dispatch, SetStateAction, useCallback, useState } from 'react';
-import Autosuggest from 'react-autosuggest';
-import { defineMessages, useIntl } from 'react-intl';
+import Autosuggest, {
+  SuggestionsFetchRequestedParams,
+} from 'react-autosuggest';
+import {
+  defineMessages,
+  FormattedMessage,
+  MessageDescriptor,
+  useIntl,
+} from 'react-intl';
 
-import { FiltersDict, QueryAutosuggestProps, SuggestionSection } from './types';
+import { appData } from 'appData';
+import { getUserFullname } from 'utils/user';
+import {
+  FilterColumns,
+  FiltersDict,
+  QueryAutosuggestProps,
+  Suggestion,
+  SuggestionSection,
+} from './types';
 
 const messages = defineMessages({
   queryPlaceholder: {
@@ -11,7 +28,171 @@ const messages = defineMessages({
     description: 'Placeholder for the query input in referral table.',
     id: 'components.ReferralTable.Input.queryPlaceholder',
   },
+  suggestionSectionAssignees: {
+    defaultMessage: 'Assignees',
+    description:
+      'Title for the suggestion section in the search autocomplete dropdown.',
+    id: 'components.ReferralTable.Input.suggestionSectionAssignees',
+  },
+  suggestionSectionTopics: {
+    defaultMessage: 'Topics',
+    description:
+      'Title for the suggestion section in the search autocomplete dropdown.',
+    id: 'components.ReferralTable.Input.suggestionSectionTopics',
+  },
+  suggestionSectionUnits: {
+    defaultMessage: 'Units',
+    description:
+      'Title for the suggestion section in the search autocomplete dropdown.',
+    id: 'components.ReferralTable.Input.suggestionSectionUnits',
+  },
+  suggestionSectionUsers: {
+    defaultMessage: 'Requesters',
+    description:
+      'Title for the suggestion section in the search autocomplete dropdown.',
+    id: 'components.ReferralTable.Input.suggestionSectionUsers',
+  },
 });
+
+const SUGGESTION_SECTIONS = [
+  {
+    column: FilterColumns.TOPIC,
+    kind: 'topiclites',
+    title: messages.suggestionSectionTopics,
+  },
+  {
+    column: FilterColumns.UNIT,
+    kind: 'unitlites',
+    title: messages.suggestionSectionUnits,
+  },
+  {
+    column: FilterColumns.USER,
+    kind: 'userlites',
+    title: messages.suggestionSectionUsers,
+  },
+  {
+    column: FilterColumns.ASSIGNEE,
+    kind: 'userlites',
+    title: messages.suggestionSectionAssignees,
+  },
+];
+
+/**
+ * `react-autosuggest` callback to get a human string value from a Suggestion object.
+ * @param suggestion The relevant suggestion object.
+ */
+export const getSuggestionValue: Autosuggest.GetSuggestionValue<Suggestion> = (
+  suggestion,
+) => {
+  switch (suggestion.kind) {
+    case 'topiclites':
+      return suggestion.value.name;
+    case 'unitlites':
+      return suggestion.value.name;
+    case 'userlites':
+      return getUserFullname(suggestion.value);
+  }
+};
+
+/**
+ * Build a suggestion section from a model name and a title, requesting the relevant
+ * values to populate it from the API
+ * @param kind The kind of suggestion we're issuing the completion request for. Determines the API
+ * endpoint we're sending the request to.
+ * @param title MessageDescriptor for the title of the section that displays the suggestions.
+ * @param query The actual payload to run the completion search with.
+ */
+export const getSuggestionsSection = async (
+  {
+    column,
+    kind,
+    title,
+  }: { column: FilterColumns; kind: string; title: MessageDescriptor },
+  query: string,
+) => {
+  // Run the search for the section on the API
+  let response: Response;
+  try {
+    response = await fetch(
+      `/api/${kind}/autocomplete/?${stringify({ query })}`,
+      {
+        headers: {
+          Authorization: `Token ${appData.token}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    return;
+  }
+
+  if (!response.ok) {
+    Sentry.captureException(
+      response.status === 400
+        ? await response.json()
+        : new Error(
+            `Failed to get list from ${kind} autocomplete : ${response.status}`,
+          ),
+    );
+    return;
+  }
+
+  let responseData: { count: number; results: Suggestion['value'][] };
+  try {
+    responseData = await response.json();
+  } catch (error) {
+    Sentry.captureException(
+      new Error('Failed to decode JSON in getSuggestionSection ' + error),
+    );
+    return;
+  }
+
+  return {
+    kind,
+    title,
+    values: responseData.results
+      .filter((_, index) => index < 3)
+      .map((value) => ({ column, kind, value })),
+  };
+};
+
+/**
+ * `react-autosuggest` callback to build up the list of suggestions and sections whenever user
+ * interaction requires us to create or update that list.
+ * @param filters The general filters object as returned by the API on a course search.
+ * @param setSuggestions The suggestion setter method for the component using our helper.
+ * @param incomingValue The current value of the search suggest form field.
+ */
+const onSuggestionsFetchRequested = async (
+  setSuggestions: (suggestions: SuggestionSection[]) => void,
+  params: SuggestionsFetchRequestedParams,
+) => {
+  if (params.value.length < 3) {
+    return setSuggestions([]);
+  }
+
+  // Fetch the suggestions for each resource-based section to build out the sections
+  let sections: SuggestionSection[];
+  try {
+    sections = (
+      await Promise.all(
+        SUGGESTION_SECTIONS.map((filterdef) =>
+          getSuggestionsSection(filterdef, params.value),
+        ),
+        // We can assert this because of the catch below
+      )
+    ).filter((section) => !!section) as SuggestionSection[];
+  } catch (error) {
+    Sentry.captureException(error);
+    return;
+  }
+
+  setSuggestions(
+    // Drop sections with no results as there's no use displaying them
+    sections.filter((section) => !!section!.values.length),
+  );
+};
 
 type QueryInputProps = {
   setFilters: Dispatch<SetStateAction<FiltersDict>>;
@@ -53,7 +234,7 @@ export const QueryInput = ({ setFilters }: QueryInputProps) => {
    * Debounce the searchAsTheUserTypes method. We have to memoize it to prevent creation to a new
    * debounce timer at each render. We only update this function when searchAsTheUserTypes change.
    */
-  const updateCourseSearchParamsDebounced = useCallback(
+  const updateSearchParamsDebounced = useCallback(
     debounce(searchAsTheUserTypes, 500, { maxWait: 1100 }),
     [searchAsTheUserTypes],
   );
@@ -69,25 +250,50 @@ export const QueryInput = ({ setFilters }: QueryInputProps) => {
     onChange: (_, { method, newValue }) => {
       // Always update the state, delegate search-as-the-user-types to debounced function
       setValue(newValue);
-      updateCourseSearchParamsDebounced(_, { method, newValue });
+      updateSearchParamsDebounced(_, { method, newValue });
     },
     placeholder: intl.formatMessage(messages.queryPlaceholder),
     value,
   };
 
   return (
-    <Autosuggest
-      getSectionSuggestions={(section) => section.values}
-      getSuggestionValue={(suggestion) => suggestion.title}
-      inputProps={inputProps}
-      multiSection={true}
-      onSuggestionsClearRequested={() => setSuggestions([])}
-      onSuggestionsFetchRequested={() => {}}
-      onSuggestionSelected={() => {}}
-      renderSectionTitle={(section) => section.title}
-      renderSuggestion={(suggestion) => <span>{suggestion.title}</span>}
-      shouldRenderSuggestions={(val) => val.length > 2}
-      suggestions={suggestions as any}
-    />
+    <div className="react-autosuggest-with-sections">
+      <Autosuggest
+        getSectionSuggestions={(section) => section.values}
+        getSuggestionValue={getSuggestionValue}
+        inputProps={inputProps}
+        multiSection={true}
+        onSuggestionsClearRequested={() => setSuggestions([])}
+        onSuggestionsFetchRequested={(params) =>
+          onSuggestionsFetchRequested(setSuggestions, params)
+        }
+        onSuggestionSelected={(_, { suggestion }) => {
+          // Add the suggestion to the existing list for the filter, if it exists, and
+          // deduplicate. Otherwise create the list with this one suggestion.
+          setFilters((filters) => ({
+            ...filters,
+            [suggestion.column]: filters[suggestion.column]
+              ? [
+                  ...new Set([
+                    ...filters[suggestion.column]!,
+                    suggestion.value.id,
+                  ]),
+                ]
+              : [suggestion.value.id],
+            query: '',
+          }));
+          // Empty full-text search so the user can make see results with the newly added filter
+          setValue('');
+        }}
+        renderSectionTitle={(section) => (
+          <FormattedMessage {...section.title} />
+        )}
+        renderSuggestion={(suggestion) => (
+          <span>{getSuggestionValue(suggestion)}</span>
+        )}
+        shouldRenderSuggestions={(val) => val.length > 2}
+        suggestions={suggestions}
+      />
+    </div>
   );
 };

--- a/src/frontend/js/components/ReferralTable/index.tsx
+++ b/src/frontend/js/components/ReferralTable/index.tsx
@@ -73,49 +73,6 @@ type SortingKey =
 type SortingDirection = 'asc' | 'desc';
 type SortingDict = { sort: SortingKey; sort_dir: SortingDirection };
 
-const processFiltersDict = (filtersDict: FiltersDict) => {
-  const processedFilters: UseReferralLitesParams = {
-    query: filtersDict.query || undefined,
-  };
-
-  if (filtersDict[FilterColumns.ASSIGNEE]) {
-    processedFilters.assignee = filtersDict[FilterColumns.ASSIGNEE]!.map(
-      (user) => user.id,
-    );
-  }
-
-  if (filtersDict[FilterColumns.STATE]) {
-    processedFilters.state = filtersDict[FilterColumns.STATE];
-  }
-
-  if (filtersDict[FilterColumns.UNIT]) {
-    processedFilters.unit = filtersDict[FilterColumns.UNIT]!.map(
-      (unit) => unit.id,
-    );
-  }
-  if (filtersDict[FilterColumns.TOPIC]) {
-    processedFilters.topic = filtersDict[FilterColumns.TOPIC]!.map(
-      (topic) => topic.id,
-    );
-  }
-  if (filtersDict[FilterColumns.USER_UNIT_NAME]) {
-    processedFilters.users_unit_name = filtersDict[
-      FilterColumns.USER_UNIT_NAME
-    ]!.map((user) => user.unit_name);
-  }
-
-  if (filtersDict[FilterColumns.DUE_DATE]) {
-    processedFilters.due_date_after = filtersDict[
-      FilterColumns.DUE_DATE
-    ]!.due_date_after.toISOString().substring(0, 10);
-    processedFilters.due_date_before = filtersDict[
-      FilterColumns.DUE_DATE
-    ]!.due_date_before.toISOString().substring(0, 10);
-  }
-
-  return processedFilters;
-};
-
 const SortingButton: React.FC<{
   sortingKey: SortingKey;
   setSorting: React.Dispatch<React.SetStateAction<SortingDict>>;
@@ -178,7 +135,7 @@ export const ReferralTable: React.FC<ReferralTableProps> = ({
 
   const { data, status } = useReferralLites({
     ...defaultParams,
-    ...processFiltersDict(filters),
+    ...filters,
     ...sorting,
   });
 

--- a/src/frontend/js/components/ReferralTable/sharedMessages.tsx
+++ b/src/frontend/js/components/ReferralTable/sharedMessages.tsx
@@ -1,0 +1,48 @@
+import { defineMessages } from 'react-intl';
+
+import { FilterColumns } from './types';
+
+export const sharedMessages = defineMessages({
+  [FilterColumns.ASSIGNEE]: {
+    defaultMessage: 'Assignee',
+    description:
+      'Name for the column filter for assignee in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnAssignee',
+  },
+  [FilterColumns.DUE_DATE]: {
+    defaultMessage: 'Due date',
+    description:
+      'Name for the column filter for due date in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnDueDate',
+  },
+  [FilterColumns.STATE]: {
+    defaultMessage: 'State',
+    description:
+      'Name for the column filter for state in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnState',
+  },
+  [FilterColumns.UNIT]: {
+    defaultMessage: 'Unit',
+    description:
+      'Name for the column filter for unit in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnUnit',
+  },
+  [FilterColumns.USER]: {
+    defaultMessage: 'Requester',
+    description:
+      'Name for the column filter for unit in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnUser',
+  },
+  [FilterColumns.USER_UNIT_NAME]: {
+    defaultMessage: 'Requester unit',
+    description:
+      'Name for the column filter for user in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnUserUnitName',
+  },
+  [FilterColumns.TOPIC]: {
+    defaultMessage: 'Topic',
+    description:
+      'Name for the column filter for user in the filters dropdown menu in referral table.',
+    id: 'components.ReferralTable.sharedMessages.columnTopic',
+  },
+});

--- a/src/frontend/js/components/ReferralTable/types.tsx
+++ b/src/frontend/js/components/ReferralTable/types.tsx
@@ -1,4 +1,5 @@
 import { AutosuggestProps } from 'react-autosuggest';
+import { MessageDescriptor } from 'react-intl';
 
 import * as types from 'types';
 
@@ -20,14 +21,33 @@ export type FiltersDict = Partial<{
   };
   [FilterColumns.STATE]: types.ReferralState[];
   [FilterColumns.UNIT]: string[];
+  [FilterColumns.USER]: string[];
   [FilterColumns.USER_UNIT_NAME]: string[];
   [FilterColumns.TOPIC]: string[];
   query: string;
 }>;
 
-export type Suggestion = { title: string };
+export type Suggestion =
+  | {
+      column: FilterColumns.TOPIC;
+      kind: 'topiclites';
+      value: types.TopicLite;
+    }
+  | {
+      column: FilterColumns.UNIT;
+      kind: 'unitlites';
+      value: types.UnitLite;
+    }
+  | {
+      column: FilterColumns.ASSIGNEE | FilterColumns.USER;
+      kind: 'userlites';
+      value: types.UserLite;
+    };
 
-export type SuggestionSection = { title: string };
+export type SuggestionSection = {
+  title: MessageDescriptor;
+  values: Suggestion[];
+};
 
 export type QueryAutosuggestProps = AutosuggestProps<
   Suggestion,

--- a/src/frontend/js/components/ReferralTable/types.tsx
+++ b/src/frontend/js/components/ReferralTable/types.tsx
@@ -7,19 +7,21 @@ export enum FilterColumns {
   DUE_DATE = 'due_date',
   STATE = 'state',
   UNIT = 'unit',
+  USER = 'user',
   USER_UNIT_NAME = 'users_unit_name',
   TOPIC = 'topic',
 }
+
 export type FiltersDict = Partial<{
-  [FilterColumns.ASSIGNEE]: types.UserLite[];
+  [FilterColumns.ASSIGNEE]: string[];
   [FilterColumns.DUE_DATE]: {
-    due_date_after: Date;
-    due_date_before: Date;
+    due_date_after: string;
+    due_date_before: string;
   };
   [FilterColumns.STATE]: types.ReferralState[];
-  [FilterColumns.UNIT]: types.Unit[];
-  [FilterColumns.USER_UNIT_NAME]: types.UserLite[];
-  [FilterColumns.TOPIC]: types.Topic[];
+  [FilterColumns.UNIT]: string[];
+  [FilterColumns.USER_UNIT_NAME]: string[];
+  [FilterColumns.TOPIC]: string[];
   query: string;
 }>;
 

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -226,16 +226,6 @@ export type ReferralActivity =
   | ReferralActivityValidationDenied
   | ReferralActivityValidationRequested;
 
-interface TopicLegacy {
-  created_at: string;
-  id: string;
-  is_active: boolean;
-  path: string;
-  parent: string;
-  name: string;
-  unit: Unit;
-}
-
 export interface Topic {
   created_at: string;
   id: string;
@@ -247,12 +237,19 @@ export interface Topic {
   unit_name: Unit['name'];
 }
 
+export type TopicLite = Pick<
+  Topic,
+  'created_at' | 'id' | 'name' | 'path' | 'unit_name'
+>;
+
 export interface Unit {
   created_at: string;
   id: string;
   members: UnitMember[];
   name: string;
 }
+
+export type UnitLite = Pick<Unit, 'id' | 'name'>;
 
 export interface UnitMember extends User {
   membership: UnitMembership;


### PR DESCRIPTION
## Purpose

We have an existing UI to add filters by manually picking a column and then entering a value for that column.

As we added a full-text search field, we decided to use it to enable autocompletion searches for filters that would match what is currently entered. This way, we can provide an alternate, quicker way to let users add filters, that is also more easily discoverable.

## Proposal

- [x] rework referral table to store strings for filters
- [x] add autocompletion suggestions on referral table