### PR TITLE
Allow users to create versions in referral validation state

### DIFF
--- a/src/backend/partaj/core/models/referral.py
+++ b/src/backend/partaj/core/models/referral.py
@@ -458,9 +458,11 @@ class Referral(models.Model):
             ReferralState.RECEIVED,
             ReferralState.PROCESSING,
             ReferralState.ASSIGNED,
+            ReferralState.IN_VALIDATION,
         ],
         target=RETURN_VALUE(
             ReferralState.PROCESSING,
+            ReferralState.IN_VALIDATION,
         ),
     )
     def add_version(self, version):
@@ -497,7 +499,7 @@ class Referral(models.Model):
             item_content_object=version,
         )
 
-        if self.state in [ReferralState.PROCESSING]:
+        if self.state in [ReferralState.PROCESSING, ReferralState.IN_VALIDATION]:
             return self.state
 
         return ReferralState.PROCESSING

--- a/src/backend/tests/partaj/core/test_api_referralreportversion.py
+++ b/src/backend/tests/partaj/core/test_api_referralreportversion.py
@@ -7,6 +7,9 @@ from rest_framework.authtoken.models import Token
 
 from partaj.core import factories, models
 
+from utils.api_reportmessage import api_send_report_message
+from utils.mock_referral import mock_create_referral
+
 
 class ReferralReportVersionApiTestCase(TestCase):
     """
@@ -18,80 +21,82 @@ class ReferralReportVersionApiTestCase(TestCase):
         """
         Save referral and send it.
         """
+        referral_unit = factories.UnitFactory()
         asker = factories.UserFactory()
-        unit_member = factories.UserFactory()
-        topic = factories.TopicFactory()
-        urgency_level = factories.ReferralUrgencyFactory()
-        referral = factories.ReferralFactory(state=models.ReferralState.DRAFT)
-        referral.users.set([asker.id])
-
-        referral.units.get().members.add(unit_member)
-        form_data = {
-            "question": "la question",
-            "context": "le contexte",
-            "object": "l'object",
-            "prior_work": "le travail prÃ©alable",
-            "topic": str(topic.id),
-            "urgency_level": str(urgency_level.id),
-            "urgency_explanation": "la justification de l'urgence",
-        }
-
-        asker_token = Token.objects.get_or_create(user=asker)[0]
-        self.client.post(
-            f"/api/referrals/{referral.id}/send/",
-            form_data,
-            HTTP_AUTHORIZATION=f"Token {asker_token}",
+        unit_membership_member = factories.UnitMembershipFactory(
+            unit=referral_unit, role=models.UnitMembershipRole.MEMBER
         )
-        created_referral = models.Referral.objects.get(id=referral.id)
+        unit_membership_member_token = Token.objects.get_or_create(user=unit_membership_member.user)[0]
 
+        unit_membership_owner = factories.UnitMembershipFactory(
+            unit=referral_unit, role=models.UnitMembershipRole.OWNER
+        )
+        unit_membership_owner_token = Token.objects.get_or_create(user=unit_membership_owner.user)[0]
+
+        report = factories.ReferralReportFactory()
+        created_referral = mock_create_referral(models.ReferralState.RECEIVED, report,
+                                                referral_unit, [asker])
+
+        # - Send a first report version by unit member
         first_attachment_file = BytesIO(b"attachment_file")
-        second_attachment_file = BytesIO(b"attachment_file2")
         first_attachment_file.name = "the first attachment file name"
-        second_attachment_file.name = "the second attachment file name"
-
-        unit_member_token = Token.objects.get_or_create(user=unit_member)[0]
-        """
-        Send two referral report versions with the same unit membership.
-        """
         first_version_response = self.client.post(
             "/api/referralreportversions/",
             {"report": str(created_referral.report.id), "files": (first_attachment_file,)},
-            HTTP_AUTHORIZATION=f"Token {unit_member_token}",
+            HTTP_AUTHORIZATION=f"Token {unit_membership_member_token}",
         )
 
+        # -> The version document is well created
+        first_document = models.VersionDocument.objects.get(
+            id=first_version_response.json()["document"]["id"])
+        self.assertEqual(first_version_response.status_code, 201)
+        self.assertEqual(first_document.name, "the first attachment file name")
+        self.assertEqual(first_document.size, 15)
+
+        # -> The referral state goes to PROCESSING
+        created_referral.refresh_from_db()
+        self.assertEqual(created_referral.state, models.ReferralState.PROCESSING)
+
+        # - Assert that a non unit member can't send a version in the report
+        asker_token = Token.objects.get_or_create(user=asker)[0]
         unauthorized_version_response = self.client.post(
             "/api/referralreportversions/",
             {"report": str(created_referral.report.id), "files": (first_attachment_file,)},
             HTTP_AUTHORIZATION=f"Token {asker_token}",
         )
+        self.assertEqual(unauthorized_version_response.status_code, 403)
 
+        # The unit member ask for validation to the unit owner sending a notification into the report message
+        api_send_report_message(self.client, report, unit_membership_member.user,
+                                [unit_membership_owner.user])
+        created_referral.refresh_from_db()
+        # -> The referral state goes to IN_VALIDATION
+        self.assertEqual(created_referral.state, models.ReferralState.IN_VALIDATION)
+
+        # Assert that the unit owner can add a version even if the referral state is IN_VALIDATION
+        second_attachment_file = BytesIO(b"attachment_file2")
+        second_attachment_file.name = "the second attachment file name"
         second_version_response = self.client.post(
             "/api/referralreportversions/",
             {"report": str(created_referral.report.id), "files": (second_attachment_file,)},
-            HTTP_AUTHORIZATION=f"Token {unit_member_token}",
+            HTTP_AUTHORIZATION=f"Token {unit_membership_owner_token}",
         )
+        second_document = models.VersionDocument.objects.get(
+            id=second_version_response.json()["document"]["id"])
+        self.assertEqual(second_version_response.status_code, 201)
+        self.assertEqual(second_document.name, "the second attachment file name")
+        self.assertEqual(second_document.size, 16)
 
-        self.assertEqual(unauthorized_version_response.status_code, 403)
-
-        self.assertEqual(first_version_response.status_code, 201)
-        first_document = models.VersionDocument.objects.get(id=first_version_response.json()["document"]["id"])
-        self.assertEqual(first_document.name, "the first attachment file name")
-        self.assertEqual(first_document.size, 15)
-
-        self.assertEqual(second_version_response.status_code, 403)
-
-        """
-        Get the report.
-        """
+        # Get the report and check if everything is ok.
         response = self.client.get(
             f"/api/referralreports/{created_referral.report.id}/",
-            HTTP_AUTHORIZATION=f"Token {unit_member_token}",
+            HTTP_AUTHORIZATION=f"Token {unit_membership_member_token}",
         )
-
-        self.assertEqual(response.json()["versions"][0]["document"]["name"], "the first attachment file name")
-
-        self.assertEqual(len(response.json()["versions"]), 1)
-
+        # -> First version is the last created
+        self.assertEqual(response.json()["versions"][0]["document"]["name"],
+                         "the second attachment file name")
+        # -> Two version were created
+        self.assertEqual(len(response.json()["versions"]), 2)
         self.assertEqual(response.status_code, 200)
 
     def test_cant_create_version_if_referral_is_already_published(self):
@@ -273,6 +278,7 @@ class ReferralReportVersionApiTestCase(TestCase):
             HTTP_AUTHORIZATION=f"Token {second_unit_member_token}",
         )
 
-        self.assertEqual(response.json()["versions"][0]["document"]["name"], "the third attachment file name")
+        self.assertEqual(response.json()["versions"][0]["document"]["name"],
+                         "the third attachment file name")
         self.assertEqual(len(response.json()["versions"]), 2)
         self.assertEqual(response.status_code, 200)

--- a/src/backend/tests/partaj/core/utils/api_reportmessage.py
+++ b/src/backend/tests/partaj/core/utils/api_reportmessage.py
@@ -1,0 +1,26 @@
+
+import json
+
+from rest_framework.authtoken.models import Token
+
+
+def api_send_report_message(client, report, sender_user, notified_users=None):
+    form_data = {
+        "content": "some message",
+        "report": str(report.id)
+    }
+
+    if notified_users:
+        form_data["notifications"] = json.dumps([
+            str(notified_user.id)
+            for notified_user in notified_users
+        ])
+    token = Token.objects.get_or_create(user=sender_user)[0]
+
+    # Send a notification to the unit admin with no previous version sent
+    return client.post(
+        "/api/reportmessages/",
+        form_data,
+        content_type='application/json',
+        HTTP_AUTHORIZATION=f"Token {token}",
+    )

--- a/src/backend/tests/partaj/core/utils/mock_referral.py
+++ b/src/backend/tests/partaj/core/utils/mock_referral.py
@@ -1,0 +1,18 @@
+from partaj.core import factories
+
+
+def mock_create_referral(state, report, unit=None, askers=None):
+    referral = factories.ReferralFactory(
+        state=state,
+        report=report
+    )
+
+    if unit:
+        referral.units.set([unit])
+    if askers:
+        referral.users.set([
+            asker.id
+            for asker in askers
+        ])
+
+    return referral

--- a/src/frontend/js/utils/user.ts
+++ b/src/frontend/js/utils/user.ts
@@ -23,7 +23,7 @@ export const getUserInitials = (user: Pick<User, 'first_name' | 'last_name'>) =>
   user.first_name[0] + user.last_name[0];
 
 /**
- * Check if user has a special ROLE i.e. ADMIN or OWNER
+ * Check if user has an ADMIN role into his units
  */
 export const isAdmin = (user: Nullable<User>) => {
   return (


### PR DESCRIPTION
**[BUG] au chargement d’une nouvelle version alors que le statut de la saisine est A valider, je ne vois pas un loader infini au niveau de la version**
https://www.notion.so/Produit-831f9b652cc1473085584e43333c7140?p=2dc4f74388bd441cada517706027ee9f&pm=s