### PR TITLE
Fix the urgency value send after previous update in the referral header urgency form

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ $ docker-compose exec app python manage.py migrate
 
 # Compiler les traductions du backend (pour avoir l'interface en français)
 $ docker-compose exec app python manage.py compilemessages
+
+# Initialisation d'elasticsearch
+$ docker-compose exec app python manage.py bootstrap_elasticsearch
 ```
 
 Par défaut, l'application devrait ensuite être en ligne sur localhost: `127.0.0.1:8080`.

--- a/src/frontend/js/components/ReferralDetail/Header/ChangeUrgencyLevelModal.tsx
+++ b/src/frontend/js/components/ReferralDetail/Header/ChangeUrgencyLevelModal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useUIDSeed } from 'react-uid';
 
@@ -95,6 +95,12 @@ const ChangeUrgencyLevelForm: React.FC<ChangeUrgencyLevelFormProps> = ({
   const sortedLevels = referralUrgencyLevels.filter(
     (urgency) => !(urgency.id === referral.urgency_level.id),
   );
+
+  useEffect(() => {
+    // When updating the urgency level, reset the default value of the
+    // urgency level selector
+    setNewUrgencylevelId(String(sortedLevels[0].id));
+  }, [referral.urgency_level.id])
 
   // Keep track of the first form submission to show validation errors
   const [isFormCleaned, setIsFormCleaned] = useState(false);

--- a/src/frontend/js/components/ReferralDetail/Header/ChangeUrgencyLevelModal.tsx
+++ b/src/frontend/js/components/ReferralDetail/Header/ChangeUrgencyLevelModal.tsx
@@ -100,7 +100,7 @@ const ChangeUrgencyLevelForm: React.FC<ChangeUrgencyLevelFormProps> = ({
     // When updating the urgency level, reset the default value of the
     // urgency level selector
     setNewUrgencylevelId(String(sortedLevels[0].id));
-  }, [referral.urgency_level.id])
+  }, [referral.urgency_level.id]);
 
   // Keep track of the first form submission to show validation errors
   const [isFormCleaned, setIsFormCleaned] = useState(false);


### PR DESCRIPTION
Task: [notion](https://www.notion.so/R-solution-du-bug-des-3-semaines-dans-les-d-lais-396e5fc467754ad2b0f3e233d081c731)

After a first update to the urgency value in the referral header, the next updates where the default value of the selector are used won't trigger any change. That is because the value of the selector isn't reset when the referral object change and keep sending the previous value.

I also added a small detail in the README file