### PR TITLE
Separate the selectors for assignee and unit in the referral header

### DIFF
--- a/src/frontend/js/components/ReferralDetail/Header/ReferralHeader.tsx
+++ b/src/frontend/js/components/ReferralDetail/Header/ReferralHeader.tsx
@@ -5,7 +5,10 @@ import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
-import { ReferralDetailAssignment } from 'components/ReferralDetailAssignment';
+import {
+  ReferralDetailAssignmentMembers,
+  ReferralDetailAssignmentUnits,
+} from 'components/ReferralDetailAssignment';
 import { ReferralStatusBadge } from 'components/ReferralStatusBadge';
 import { useCurrentUser } from 'data/useCurrentUser';
 import * as types from 'types';
@@ -38,7 +41,6 @@ import { PriorityHeaderField } from './PriorityHeaderField';
 import { ChangeUrgencyLevelModal } from './ChangeUrgencyLevelModal';
 import { TopicSelect } from '../../select/TopicSelect';
 import { ReferralHeaderField } from './ReferralHeaderField';
-import { getLastItem } from '../../../utils/string';
 
 const messages = defineMessages({
   changeUrgencyLevel: {
@@ -427,7 +429,7 @@ export const ReferralHeader: any = () => {
                   title={intl.formatMessage(messages.assignmentTitle)}
                   icon={<UserFillIcon size={5} />}
                 >
-                  <ReferralDetailAssignment referral={referral} />
+                  <ReferralDetailAssignmentMembers referral={referral} />
                 </ReferralHeaderField>
               </div>
               <div className="flex">
@@ -435,25 +437,7 @@ export const ReferralHeader: any = () => {
                   title={intl.formatMessage(messages.unitsTitle)}
                   icon={<DeskIcon size={5} />}
                 >
-                  <div
-                    className="flex items-center px-1 tooltip tooltip-info"
-                    style={{ width: 'calc(100% - 8rem)' }}
-                    data-tooltip={referral.units
-                      .map((unit, index) => {
-                        const separator = index > 0 ? '' : ' ';
-                        return `${separator + unit.name}`;
-                      })
-                      .toString()}
-                  >
-                    <span className="text-black truncate">
-                      {referral.units.map((unit, index) => (
-                        <React.Fragment key={unit.id}>
-                          {index > 0 && ', '}
-                          {getLastItem(unit.name, '/')}
-                        </React.Fragment>
-                      ))}
-                    </span>
-                  </div>
+                  <ReferralDetailAssignmentUnits referral={referral} />
                 </ReferralHeaderField>
               </div>
             </div>

--- a/src/frontend/js/components/ReferralDetailAssignment/index.spec.tsx
+++ b/src/frontend/js/components/ReferralDetailAssignment/index.spec.tsx
@@ -10,7 +10,10 @@ import { Referral, ReferralState, Unit, UnitMembershipRole } from 'types';
 import { Deferred } from 'utils/test/Deferred';
 import * as factories from 'utils/test/factories';
 import { getUserFullname, getUserInitials } from 'utils/user';
-import { ReferralDetailAssignment } from '.';
+import {
+  ReferralDetailAssignmentMembers,
+  ReferralDetailAssignmentUnits,
+} from '.';
 
 jest.mock('./AssignUnitModal', () => ({
   AssignUnitModal: ({
@@ -58,7 +61,7 @@ describe('<ReferralDetailAssignment />', () => {
               <CurrentUserContext.Provider
                 value={{ currentUser: unit.members[0] }}
               >
-                <ReferralDetailAssignment
+                <ReferralDetailAssignmentMembers
                   referral={{
                     ...referral,
                     topic: { ...referral.topic, unit: unit.id },
@@ -132,7 +135,7 @@ describe('<ReferralDetailAssignment />', () => {
               <CurrentUserContext.Provider
                 value={{ currentUser: unit.members[0] }}
               >
-                <ReferralDetailAssignment
+                <ReferralDetailAssignmentMembers
                   referral={{
                     ...updatedReferral,
                     topic: { ...referral.topic, unit: unit.id },
@@ -188,7 +191,7 @@ describe('<ReferralDetailAssignment />', () => {
               <CurrentUserContext.Provider
                 value={{ currentUser: unit.members[0] }}
               >
-                <ReferralDetailAssignment
+                <ReferralDetailAssignmentMembers
                   referral={{
                     ...referral,
                     assignees: assignedMembers.map((assignee) => ({
@@ -291,7 +294,7 @@ describe('<ReferralDetailAssignment />', () => {
               <CurrentUserContext.Provider
                 value={{ currentUser: unit.members[0] }}
               >
-                <ReferralDetailAssignment
+                <ReferralDetailAssignmentMembers
                   referral={{
                     ...updatedReferral,
                     topic: { ...referral.topic, unit: unit.id },
@@ -370,7 +373,7 @@ describe('<ReferralDetailAssignment />', () => {
               <CurrentUserContext.Provider
                 value={{ currentUser: unit.members[0] }}
               >
-                <ReferralDetailAssignment referral={initialReferral} />
+                <ReferralDetailAssignmentUnits referral={initialReferral} />
               </CurrentUserContext.Provider>
             </QueryClientProvider>
           </IntlProvider>,
@@ -381,11 +384,6 @@ describe('<ReferralDetailAssignment />', () => {
         expect(dropdownBtn).toHaveAttribute('aria-expanded', 'false');
         // Open the dropdown menu, it defaults to the Persons tab. Move to units tab.
         userEvent.click(dropdownBtn);
-        screen.getByRole('group', {
-          name: 'Manage person assignments',
-        });
-        const unitsTabBtn = screen.getByRole('button', { name: 'Units' });
-        userEvent.click(unitsTabBtn);
         // The list of available units is loading
         screen.getByRole('status', { name: 'Loading units...' });
         await act(async () =>
@@ -462,7 +460,7 @@ describe('<ReferralDetailAssignment />', () => {
                 <CurrentUserContext.Provider
                   value={{ currentUser: unit.members[0] }}
                 >
-                  <ReferralDetailAssignment referral={updatedReferral} />
+                  <ReferralDetailAssignmentUnits referral={updatedReferral} />
                 </CurrentUserContext.Provider>
               </QueryClientProvider>
             </IntlProvider>,
@@ -525,7 +523,7 @@ describe('<ReferralDetailAssignment />', () => {
               <CurrentUserContext.Provider
                 value={{ currentUser: unit.members[0] }}
               >
-                <ReferralDetailAssignment
+                <ReferralDetailAssignmentMembers
                   referral={{
                     ...referral,
                     assignees: assignedMembers.map((assignee) => ({
@@ -577,7 +575,7 @@ describe('<ReferralDetailAssignment />', () => {
             <CurrentUserContext.Provider
               value={{ currentUser: unit.members[0] }}
             >
-              <ReferralDetailAssignment
+              <ReferralDetailAssignmentMembers
                 referral={{
                   ...referral,
                   topic: { ...referral.topic, unit: unit.id },
@@ -604,7 +602,7 @@ describe('<ReferralDetailAssignment />', () => {
       render(
         <IntlProvider locale="en">
           <QueryClientProvider client={queryClient}>
-            <ReferralDetailAssignment
+            <ReferralDetailAssignmentMembers
               referral={{
                 ...referral,
                 assignees: [assignee1, assignee2].map((assignee) => ({
@@ -646,7 +644,7 @@ describe('<ReferralDetailAssignment />', () => {
       render(
         <IntlProvider locale="en">
           <QueryClientProvider client={queryClient}>
-            <ReferralDetailAssignment
+            <ReferralDetailAssignmentMembers
               referral={{
                 ...referral,
                 topic: { ...referral.topic, unit: unit.id },
@@ -672,7 +670,7 @@ describe('<ReferralDetailAssignment />', () => {
       render(
         <IntlProvider locale="en">
           <QueryClientProvider client={queryClient}>
-            <ReferralDetailAssignment
+            <ReferralDetailAssignmentMembers
               referral={{
                 ...referral,
                 assignees: [assignee1, assignee2].map((assignee) => ({


### PR DESCRIPTION
Task: [notion](https://www.notion.so/Faire-affectation-unit-s-au-niveau-du-champ-bureau-x-42d4bf4b6eab4f36b4b685a0cda10d27)

Separate the component `ReferralDetailsAssignment` into `ReferralDetailsAssignmentMembers` and `ReferralDetailsAssignmentUnits` to allow using separate selectors for members and units in the referral header instead of using one with tabs inside.