### PR TITLE
Add titles to the member and unit dropdown in referral header

### DIFF
--- a/src/frontend/js/components/ReferralDetailAssignment/index.tsx
+++ b/src/frontend/js/components/ReferralDetailAssignment/index.tsx
@@ -14,6 +14,7 @@ import { getLastItem } from 'utils/string';
 import { ReferralMemberAssignmentButton } from './ReferralMemberAssignmentButton';
 import { ReferralUnitAssignmentButton } from './ReferralUnitAssignmentButton';
 import { AssignmentDropdownButton } from '../DropdownMenu/AssignmentDropdownMenu';
+import { appData } from 'appData';
 
 const messages = defineMessages({
   addAnAssignee: {
@@ -202,9 +203,19 @@ export const ReferralDetailAssignmentMembers: React.FC<ReferralDetailAssignmentM
           {dropdown.getDropdownContainer(
             <div data-testid="dropdown-inside-container">
               <div
-                className="flex py-2 overflow-auto"
+                className="flex flex-col py-2 overflow-auto"
                 style={{ minHeight: '8rem', maxHeight: '28rem' }}
               >
+                <div className="flex flex-row items-center justify-center pb-2 border-b">
+                  <svg className="fill-current w-4 h-4 mr-2" aria-hidden={true}>
+                    <use
+                      xlinkHref={`${appData.assets.icons}#icon-person-outline`}
+                    />
+                  </svg>
+                  <span>
+                    <FormattedMessage {...messages.tabTitlePersons} />
+                  </span>
+                </div>
                 <ReferralDetailAssignmentMembersTab referral={referral} />
               </div>
             </div>,
@@ -364,9 +375,17 @@ export const ReferralDetailAssignmentUnits: React.FC<ReferralDetailAssignmentUni
           {dropdown.getDropdownContainer(
             <div data-testid="dropdown-inside-container">
               <div
-                className="flex py-2 overflow-auto"
+                className="flex flex-col py-2 overflow-auto"
                 style={{ minHeight: '8rem', maxHeight: '28rem' }}
               >
+                <div className="flex flex-row items-center justify-center pb-2 border-b">
+                  <svg className="fill-current w-4 h-4 mr-2" aria-hidden={true}>
+                    <use xlinkHref={`${appData.assets.icons}#icon-cluster`} />
+                  </svg>
+                  <span>
+                    <FormattedMessage {...messages.tabTitleUnits} />
+                  </span>
+                </div>
                 <ReferralDetailAssignmentUnitsTab
                   referral={referral}
                   setIsKeepDropdownMenu={setIsKeepDropdownMenu}


### PR DESCRIPTION
Task: [notion](https://www.notion.so/Faire-affectation-unit-s-au-niveau-du-champ-bureau-x-42d4bf4b6eab4f36b4b685a0cda10d27)
Revision based on comment: [re-add previously existing titles from when the dropdown had tabs](https://www.notion.so/Faire-affectation-unit-s-au-niveau-du-champ-bureau-x-42d4bf4b6eab4f36b4b685a0cda10d27?d=3841a8948d4945b1974b33d0ccad921e)

Copy the pre-existing titles and put them in each individual dropdown for member and unit in referral header