### PR TITLE
Refetch the referral after mutating to close

### DIFF
--- a/src/frontend/js/components/ReferralDetail/Header/CloseReferralModal.tsx
+++ b/src/frontend/js/components/ReferralDetail/Header/CloseReferralModal.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useUIDSeed } from 'react-uid';
 import { uniq } from 'lodash-es';
 
 import { useReferralAction } from 'data';
 import { useCurrentUser } from 'data/useCurrentUser';
+import { ReferralContext } from 'data/providers/ReferralProvider';
 import { hasMembership } from 'utils/user';
 import { Referral } from 'types';
 import { getLastItem } from 'utils/string';
@@ -75,6 +76,7 @@ export const CloseReferralModal: React.FC<CloseReferralModalProps> = ({
 }) => {
   const seed = useUIDSeed();
   const mutation = useReferralAction();
+  const { setReferral } = useContext(ReferralContext);
   const { currentUser } = useCurrentUser();
 
   const isUserRequester = !hasMembership(currentUser);
@@ -100,6 +102,7 @@ export const CloseReferralModal: React.FC<CloseReferralModalProps> = ({
       setIsCloseReferralModalOpen(false);
       setIsFormCleaned(false);
       setCloseReferralExplanation('');
+      setReferral(mutation.data);
     }
   }, [mutation.status]);
 


### PR DESCRIPTION
Task: [notion](https://www.notion.so/Cl-ture-MAJ-automatique-de-la-saisine-apr-s-cl-ture-edf32b97080c4d5eaf0e3a5d6b1caf64?pvs=4)

Force the refetch of the referral after mutating to close in the `CloseReferralModal`