### PR TITLE
Fix inviting an existing user by email by adjusting the DB search

### DIFF
--- a/src/backend/partaj/core/api/referral.py
+++ b/src/backend/partaj/core/api/referral.py
@@ -532,9 +532,7 @@ class ReferralViewSet(viewsets.ModelViewSet):
         try:
             # The guest already exists in our DB, just need to add him as a referral user
             # (requester or observer)
-            guest = user_model.objects.get(
-                email=invitation_email, username=invitation_email
-            )
+            guest = user_model.objects.get(email=invitation_email)
         except User.DoesNotExist:
             guest = user_model.objects.create(
                 email=invitation_email, username=invitation_email


### PR DESCRIPTION
Task: [notion](https://www.notion.so/Erreur-d-ajout-par-mail-de-demandeur-existant-dans-la-BDD-ffaff2f14e6745cab72cf484bac5655b?pvs=4)

Remove the search on the username when trying to find a duplicate user as the username gets updated when registering