### PR TITLE
Remove the new version banner in the referral response page

### DIFF
--- a/src/frontend/js/components/ReferralDetail/Content/Tabs/TabReport.tsx
+++ b/src/frontend/js/components/ReferralDetail/Content/Tabs/TabReport.tsx
@@ -11,19 +11,6 @@ interface TabReportProps {
 export const TabReport: React.FC<TabReportProps> = ({ referral }) => {
   return (
     <>
-      <div className="w-full text-black border p-4">
-        Une nouvelle version de l'espace projet de réponse est désormais
-        disponible ! Pour toute information sur le fonctionnement n'hésitez pas
-        à consulter{' '}
-        <a
-          className="underline"
-          target="_blank"
-          href="https://documentation.partaj.beta.gouv.fr/guide-de-traitement-dune-saisine-1#traiter-une-saisine-qui-ma-ete-affectee-apres-le-04-11-2022"
-        >
-          la documentation
-        </a>{' '}
-        ou à nous contacter par tchat
-      </div>
       <div className="flex space-x-4 float-right mb-8">
         <DownloadReferralButton referralId={String(referral!.id)} />
       </div>


### PR DESCRIPTION
Task: [notion](https://www.notion.so/Retirer-l-encart-d-avertissement-sur-l-espace-de-r-ponse-1d873e70c91441619d9993e4ae47f0be?pvs=4)

Remove the "new version of the referral response" banner in the referral response page now that it's been released for some time